### PR TITLE
PP-3: Arbiter Smart Contract

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ parameters:
         default: "rsksmart/rskj.git"
     version:
         type: string
-        default: "3.0.0-SNAPSHOT"
+        default: "3.1.0-SNAPSHOT"
     branch:
         type: string
         default: "master"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ parameters:
         default: "rsksmart/rskj.git"
     version:
         type: string
-        default: "3.1.0-SNAPSHOT"
+        default: '3.2.0-SNAPSHOT'
     branch:
         type: string
         default: "master"
@@ -69,12 +69,23 @@ commands:
       - run:
           name: "Execute << parameters.test >>"
           command: |
+                  ls ~/rsksmart/rskj/rskj-core/build/libs/
                   java -Dminer.client.autoMine=true -Drpc.providers.web.ws.enabled=true -Drsk.conf.file=~/gls/rsknode/node.conf -Dminer.minGasPrice=1 << pipeline.parameters.hardfork >> -cp ~/rsksmart/rskj/rskj-core/build/libs/rskj-core-<< pipeline.parameters.version >>-all.jar co.rsk.Start --regtest --reset nohup &
-                  until nc -z 127.0.0.1 4444
-                  do
-                   echo "Waiting for RskJ..."
-                   sleep 1
+                  
+                  _i=0
+                  while [ $_i -lt 30 ]; do
+                    curl -Ss -H "Content-type: application/json" \
+                        -d '{"jsonrpc":"2.0","method":"eth_blockNumber","id":"boot-test"}' \
+                        http://127.0.0.1:4444/ 2>/dev/null | grep -q result && break
+                    sleep 1
+                    _i=$((_i + 1))
                   done
+                  if [ $_i -eq 30 ]; then
+                    echo "No response from rskj after 30 seconds; aborting..." >&2
+                    exit 1
+                  fi
+
+                  sleep 5
                   npx truffle test --network rsk << parameters.test >>
 
 jobs: # a collection of steps
@@ -89,11 +100,18 @@ jobs: # a collection of steps
           name: Tests without DB reset Set B
           command: |
                     java -Dminer.client.autoMine=true -Drsk.conf.file=~/gls/rsknode/node.conf -Dminer.minGasPrice=1 << pipeline.parameters.hardfork >> -cp ~/rsksmart/rskj/rskj-core/build/libs/rskj-core-<< pipeline.parameters.version >>-all.jar co.rsk.Start --regtest --reset nohup &
-                    until nc -z 127.0.0.1 4444
-                    do
-                      echo "Waiting for RskJ..."
+                    _i=0
+                    while [ $_i -lt 30 ]; do
+                      curl -Ss -H "Content-type: application/json" \
+                          -d '{"jsonrpc":"2.0","method":"eth_blockNumber","id":"boot-test"}' \
+                          http://127.0.0.1:4444/ 2>/dev/null | grep -q result && break
                       sleep 1
+                      _i=$((_i + 1))
                     done
+                    if [ $_i -eq 30 ]; then
+                      echo "No response from rskj after 30 seconds; aborting..." >&2
+                      exit 1
+                    fi
                     npx truffle test --network rsk test/Verifiers.test.ts
                     npx truffle test --network rsk test/RelayHubPenalizations.test.ts
                     npx truffle test --network rsk test/RelayHubRegistrationsManagement.test.ts
@@ -167,11 +185,18 @@ jobs: # a collection of steps
           name: Tests without DB reset Set A
           command: |
                     java -Dminer.client.autoMine=true -Drsk.conf.file=~/gls/rsknode/node.conf -Dminer.minGasPrice=1 << pipeline.parameters.hardfork >> -cp ~/rsksmart/rskj/rskj-core/build/libs/rskj-core-<< pipeline.parameters.version >>-all.jar co.rsk.Start --regtest --reset nohup &
-                    until nc -z 127.0.0.1 4444
-                    do
-                      echo "Waiting for RskJ..."
+                    _i=0
+                    while [ $_i -lt 30 ]; do
+                      curl -Ss -H "Content-type: application/json" \
+                          -d '{"jsonrpc":"2.0","method":"eth_blockNumber","id":"boot-test"}' \
+                          http://127.0.0.1:4444/ 2>/dev/null | grep -q result && break
                       sleep 1
+                      _i=$((_i + 1))
                     done
+                    if [ $_i -eq 30 ]; then
+                      echo "No response from rskj after 30 seconds; aborting..." >&2
+                      exit 1
+                    fi
                     npx truffle test --network rsk test/Flows.test.ts
                     npx truffle test --network rsk test/TestEnvironment.test.ts
                     npx truffle test --network rsk test/HttpWrapper.test.ts
@@ -190,11 +215,18 @@ jobs: # a collection of steps
           name: Tests without DB reset Set C
           command: |
                     java -Dminer.client.autoMine=true -Drpc.providers.web.ws.enabled=true -Drsk.conf.file=~/gls/rsknode/node.conf -Dminer.minGasPrice=1 << pipeline.parameters.hardfork >> -cp ~/rsksmart/rskj/rskj-core/build/libs/rskj-core-<< pipeline.parameters.version >>-all.jar co.rsk.Start --regtest --reset nohup &
-                    until nc -z 127.0.0.1 4444
-                    do
-                      echo "Waiting for RskJ..."
+                    _i=0
+                    while [ $_i -lt 30 ]; do
+                      curl -Ss -H "Content-type: application/json" \
+                          -d '{"jsonrpc":"2.0","method":"eth_blockNumber","id":"boot-test"}' \
+                          http://127.0.0.1:4444/ 2>/dev/null | grep -q result && break
                       sleep 1
+                      _i=$((_i + 1))
                     done
+                    if [ $_i -eq 30 ]; then
+                      echo "No response from rskj after 30 seconds; aborting..." >&2
+                      exit 1
+                    fi
                     npx truffle test --network rsk test/relayclient/RelayClient.test.ts
                     npx truffle test --network rsk test/relayserver/NetworkSimulation.test.ts
                     npx truffle test --network rsk test/relayserver/RegistrationManager.test.ts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,7 @@ jobs: # a collection of steps
                     fi
                     npx truffle test --network rsk test/Verifiers.test.ts
                     npx truffle test --network rsk test/RelayHubPenalizations.test.ts
+                    npx truffle test --network rsk test/penalizer/Penalizer.test.ts
                     npx truffle test --network rsk test/RelayHubRegistrationsManagement.test.ts
                     npx truffle test --network rsk test/TxStoreManager.test.ts
                     npx truffle test --network rsk test/Utils.test.ts

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -148,10 +148,8 @@ contract Penalizer is IPenalizer, Ownable {
         require(fulfilledTransactions[txId] == false, "tx was fulfilled");
             
         penalizedTransactions[txId] = true;
-        (bool success, ) = hub.call(abi.encodeWithSignature("fulfill(address, address)", workerAddress, msg.sender));
+        (bool success, ) = hub.call(abi.encodeWithSignature("penalize(address, address)", workerAddress, msg.sender));
         require(success, "Relay Hub penalize call failed");
-        
-        // return outcome?
     }
 
     function splitSignature(bytes memory signature) internal pure returns (uint8, bytes32, bytes32) {

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -101,7 +101,7 @@ contract Penalizer is IPenalizer, Ownable {
     }
 
     modifier relayHubOnly() {
-        require(msg.sender == hub, "Unknown Relay Hub");
+        require(msg.sender == hub, "Unknown relay hub");
         _;
     }
 

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -15,6 +15,8 @@ import "./interfaces/IPenalizer.sol";
 contract Penalizer is IPenalizer, Ownable {
 
     string public override versionPenalizer = "2.0.1+enveloping.penalizer.ipenalizer";
+    // bytes4(keccak256("penalize(address,address)"))
+    bytes4 private constant PENALIZE_SELECTOR = 0xebcd31ac;
     
     mapping(bytes32 => bool) public penalizedTransactions;
     mapping(bytes32 => bool) public fulfilledTransactions;
@@ -107,10 +109,9 @@ contract Penalizer is IPenalizer, Ownable {
         _;
     }
 
-    function fulfill(bytes calldata txSignature) external override relayHubOnly() {
-        bytes32 txId = keccak256(txSignature);
-        require(!fulfilledTransactions[txId], "Transaction already fulfilled");
-        fulfilledTransactions[txId] = true;
+    function fulfill(bytes32 txhash) external override relayHubOnly() {
+        require(!fulfilledTransactions[txhash], "Transaction already fulfilled");
+        fulfilledTransactions[txhash] = true;
     }
 
     function fulfilled(bytes calldata txSignature) external view override returns (bool){
@@ -159,8 +160,7 @@ contract Penalizer is IPenalizer, Ownable {
         bytes32 txId = keccak256(commitmentReceipt.commitment.signature);
         require(fulfilledTransactions[txId] == false, "can't penalize fulfilled tx");
         require(penalizedTransactions[txId] == false, "tx already penalized");
-            
-        (bool success, ) = hub.call(abi.encodeWithSignature("penalize(address,address)", workerAddress, msg.sender));
+        (bool success, ) = hub.call(abi.encodeWithSelector(PENALIZE_SELECTOR, workerAddress, msg.sender));
         require(success, "Relay Hub penalize call failed");
         penalizedTransactions[txId] = true;
     }

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -1,3 +1,5 @@
+/* solhint-disable avoid-low-level-calls */
+/* solhint-disable no-inline-assembly */
 // SPDX-License-Identifier:MIT
 pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -89,9 +89,15 @@ contract Penalizer is IPenalizer {
         hub.penalize(addr1, msg.sender);
     }
 
+    modifier relayHubOnly(IRelayHub hub) {
+        require(msg.sender == address(hub), "Unknown relay hub");
+        _;
+    }
+
     function fulfill(
-        bytes memory txSignature
-    ) external override{
+        bytes memory txSignature,
+        IRelayHub hub
+    ) external override relayHubOnly(hub) {
         bytes32 txId = keccak256(txSignature);
         require(!fulfilledTransactions[txId], "tx already fulfilled");
         fulfilledTransactions[txId] = true;

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -150,9 +150,9 @@ contract Penalizer is IPenalizer, Ownable {
         require(fulfilledTransactions[txId] == false, "can't penalize fulfilled tx");
         require(penalizedTransactions[txId] == false, "tx already penalized");
             
-        penalizedTransactions[txId] = true;
         (bool success, ) = hub.call(abi.encodeWithSignature("penalize(address,address)", workerAddress, msg.sender));
         require(success, "Relay Hub penalize call failed");
+        penalizedTransactions[txId] = true;
     }
 
     function splitSignature(bytes memory signature) internal pure returns (uint8, bytes32, bytes32) {

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -101,7 +101,7 @@ contract Penalizer is IPenalizer, Ownable {
     }
 
     modifier relayHubOnly() {
-        require(msg.sender == hub, "Unknown relay hub");
+        require(msg.sender == hub, "Unknown Relay Hub");
         _;
     }
 

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -17,7 +17,7 @@ contract Penalizer is IPenalizer {
     mapping(bytes32 => bool) public fulfilledTransactions;
 
     address private owner;
-    address private hubAddress;
+    address private hub;
 
     using ECDSA for bytes32;
 
@@ -26,7 +26,7 @@ contract Penalizer is IPenalizer {
     }
 
     // temp
-    function viewOwner() external view returns (address){
+    function getOwner() external view returns (address){
         return owner;
     }
 
@@ -40,8 +40,8 @@ contract Penalizer is IPenalizer {
         return transaction;
     }
 
-    modifier relayManagerOnly(IRelayHub hub) {
-        require(hub.isRelayManagerStaked(msg.sender), "Unknown relay manager");
+    modifier relayManagerOnly(IRelayHub _hub) {
+        require(_hub.isRelayManagerStaked(msg.sender), "Unknown relay manager");
         _;
     }
 
@@ -50,8 +50,12 @@ contract Penalizer is IPenalizer {
         _;
     }
 
-    function setupHub(address _hubAddress) public override onlyOwner() {
-        hubAddress = _hubAddress;
+    function setHub(address _hub) public override onlyOwner() {
+        hub = _hub;
+    }
+
+    function getHub() external override view returns (address){
+        return hub;
     }
 
     function penalizeRepeatedNonce(
@@ -59,11 +63,11 @@ contract Penalizer is IPenalizer {
         bytes memory signature1,
         bytes memory unsignedTx2,
         bytes memory signature2,
-        IRelayHub hub
+        IRelayHub _hub
     )
     public
     override
-    relayManagerOnly(hub)
+    relayManagerOnly(_hub)
     {
         // Can be called by a relay manager only.
         // If a relay attacked the system by signing multiple transactions with the same nonce
@@ -107,11 +111,11 @@ contract Penalizer is IPenalizer {
         penalizedTransactions[txHash1] = true;
         penalizedTransactions[txHash2] = true;
 
-        hub.penalize(addr1, msg.sender);
+        _hub.penalize(addr1, msg.sender);
     }
 
     modifier relayHubOnly() {
-        require(msg.sender == hubAddress, "Unknown relay hub");
+        require(msg.sender == hub, "Unknown relay hub");
         _;
     }
 

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -53,7 +53,7 @@ contract Penalizer is IPenalizer, Ownable {
         bytes memory signature2,
         IRelayHub relayHub
     )
-    public
+    external
     override
     relayManagerOnly(relayHub)
     {

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -145,12 +145,13 @@ contract Penalizer is IPenalizer, Ownable {
         //require(commitmentReceipt.commitment.time <= block.timestamp, "too early to claim");
 
         bytes32 txId = keccak256(commitmentReceipt.commitment.signature);
-        require(fulfilledTransactions[txId] == false, "tx was fulfilled, invalid claim");
+        require(fulfilledTransactions[txId] == false, "tx was fulfilled");
             
         penalizedTransactions[txId] = true;
-        hub.penalize(workerAddress, msg.sender);
+        (bool success, ) = hub.call(abi.encodeWithSignature("fulfill(address, address)", workerAddress, msg.sender));
+        require(success, "Relay Hub penalize call failed");
         
-        // we should return something to show the outcome of the claim call (manager was penalized or not?)
+        // return outcome?
     }
 
     function splitSignature(bytes memory signature) internal pure returns (uint8, bytes32, bytes32) {

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -119,7 +119,7 @@ contract Penalizer is IPenalizer, Ownable {
         require(hub != address(0), "Relay Hub not set");
 
         // check if the commitment has enabled qos
-        require(commitmentReceipt.commitment.enableQos, "This commitment has not enabled QOS");
+        require(commitmentReceipt.commitment.enableQos, "This commitment has not enabled QoS");
 
         // check the worker address and the signature
         address workerAddress = commitmentReceipt.workerAddress;

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -128,12 +128,12 @@ contract Penalizer is IPenalizer {
     function claim(CommitmentReceipt calldata commitmentReceipt) external override {
 
         // check if the commitment has enabled qos
-        require(commitmentReceipt.commitment.enabledQos, "This commitment has not enabled QOS");
+        require(commitmentReceipt.commitment.enableQos, "This commitment has not enabled QOS");
 
         // check the worker address and the signature
         address workerAddress = commitmentReceipt.workerAddress;
         bytes memory workerSignature = commitmentReceipt.workerSignature;
-        bytes32 commitmentHash = keccak256(abi.encodePacked(commitmentReceipt.commitment.time, commitmentReceipt.commitment.from, commitmentReceipt.commitment.to, commitmentReceipt.commitment.data, commitmentReceipt.commitment.relayHubAddress, commitmentReceipt.commitment.relayWorker, commitmentReceipt.commitment.enabledQos));
+        bytes32 commitmentHash = keccak256(abi.encodePacked(commitmentReceipt.commitment.time, commitmentReceipt.commitment.from, commitmentReceipt.commitment.to, commitmentReceipt.commitment.data, commitmentReceipt.commitment.relayHubAddress, commitmentReceipt.commitment.relayWorker, commitmentReceipt.commitment.enableQos));
 
         require(recoverSigner(commitmentHash, workerSignature) == workerAddress, "This commitment is not signed by the specified worker");
         require(workerAddress == commitmentReceipt.commitment.relayWorker, "The worker address in the receipt is not the same as the commitment");

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -25,6 +25,11 @@ contract Penalizer is IPenalizer {
         owner = msg.sender;
     }
 
+    // temp
+    function viewOwner() external view returns (address){
+        return owner;
+    }
+
     function decodeTransaction(bytes memory rawTransaction) private pure returns (Transaction memory transaction) {
         (transaction.nonce,
         transaction.gasPrice,

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -107,7 +107,7 @@ contract Penalizer is IPenalizer, Ownable {
         _;
     }
 
-    function fulfill(bytes memory txSignature) external override relayHubOnly() {
+    function fulfill(bytes calldata txSignature) external override relayHubOnly() {
         bytes32 txId = keccak256(txSignature);
         require(!fulfilledTransactions[txId], "Transaction already fulfilled");
         fulfilledTransactions[txId] = true;

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -149,7 +149,7 @@ contract Penalizer is IPenalizer, Ownable {
         require(penalizedTransactions[txId] == false, "tx already penalized");
             
         penalizedTransactions[txId] = true;
-        (bool success, ) = hub.call(abi.encodeWithSignature("penalize(address, address)", workerAddress, msg.sender));
+        (bool success, ) = hub.call(abi.encodeWithSignature("penalize(address,address)", workerAddress, msg.sender));
         require(success, "Relay Hub penalize call failed");
     }
 

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -97,8 +97,8 @@ contract Penalizer is IPenalizer {
         fulfilledTransactions[txId] = true;
     }
 
-    function fulfilled(bytes calldata signature) external view override returns (bool){
-        return fulfilledTransactions[keccak256(signature)];
+    function fulfilled(bytes calldata txSignature) external view override returns (bool){
+        return fulfilledTransactions[keccak256(txSignature)];
     }
 
     function claim(CommitmentReceipt calldata commitmentReceipt) external override {

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -141,7 +141,7 @@ contract Penalizer is IPenalizer, Ownable {
         require(hub == commitmentReceipt.commitment.relayHubAddress, "relay hub does not match");
         require(msg.sender == commitmentReceipt.commitment.from, "sender does not match");
 
-        // skip time check for now
+        // skip qos check for now
         //require(commitmentReceipt.commitment.time <= block.timestamp, "too early to claim");
 
         bytes32 txId = keccak256(commitmentReceipt.commitment.signature);

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -125,8 +125,15 @@ contract Penalizer is IPenalizer {
         require(commitmentReceipt.commitment.time <= block.timestamp, "The time you agreed to wait is not due yet, this claim is not valid");
 
         // check if the transaction have been executed or not
+        bytes32 txId = keccak256(commitmentReceipt.commitment.signature);
 
-        // TODO next iteration: check if the transaction was executed in time
+        if (fulfilledTransactions[txId]) {
+            // tx was executed
+            // TODO next iteration: check if the transaction was executed in time
+        } else {
+            // tx was not executed so we should probably penalize the manager here
+        }
+        // we should return something to show the outcome of the claim call (manager was penalized or not?)
     }
 
     function splitSignature(bytes memory signature) internal pure returns (uint8, bytes32, bytes32) {

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -40,8 +40,8 @@ contract Penalizer is IPenalizer {
         return transaction;
     }
 
-    modifier relayManagerOnly(IRelayHub _hub) {
-        require(_hub.isRelayManagerStaked(msg.sender), "Unknown relay manager");
+    modifier relayManagerOnly(IRelayHub relayHub) {
+        require(relayHub.isRelayManagerStaked(msg.sender), "Unknown relay manager");
         _;
     }
 
@@ -50,8 +50,8 @@ contract Penalizer is IPenalizer {
         _;
     }
 
-    function setHub(address _hub) public override onlyOwner() {
-        hub = _hub;
+    function setHub(address relayHub) public override onlyOwner() {
+        hub = relayHub;
     }
 
     function getHub() external override view returns (address){
@@ -63,11 +63,11 @@ contract Penalizer is IPenalizer {
         bytes memory signature1,
         bytes memory unsignedTx2,
         bytes memory signature2,
-        IRelayHub _hub
+        IRelayHub relayHub
     )
     public
     override
-    relayManagerOnly(_hub)
+    relayManagerOnly(relayHub)
     {
         // Can be called by a relay manager only.
         // If a relay attacked the system by signing multiple transactions with the same nonce
@@ -111,7 +111,7 @@ contract Penalizer is IPenalizer {
         penalizedTransactions[txHash1] = true;
         penalizedTransactions[txHash2] = true;
 
-        _hub.penalize(addr1, msg.sender);
+        relayHub.penalize(addr1, msg.sender);
     }
 
     modifier relayHubOnly() {

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -142,9 +142,19 @@ contract Penalizer is IPenalizer, Ownable {
         require(workerAddress == commitmentReceipt.commitment.relayWorker, "worker address does not match");
         require(hub == commitmentReceipt.commitment.relayHubAddress, "relay hub does not match");
         require(msg.sender == commitmentReceipt.commitment.from, "receiver must claim commitment");
-
-        // skip qos check for now
-        //require(commitmentReceipt.commitment.time <= block.timestamp, "too early to claim");
+        
+        /* Although it could be a security flaw, in this case we don't need a strict
+         * time check. We are aware that the miner could tamper the block.timestamp 
+         * but right now the implementation of ethereum protocol would invalidate
+         * blocks with more than 15 seconds in future. 
+         * We can accept a variability of +15 seconds, without being impacted by that.
+         * References:
+         * - https://consensys.github.io/smart-contract-best-practices/recommendations/#timestamp-dependence
+         * - https://swcregistry.io/docs/SWC-116
+         * - https://cryptomarketpool.com/block-timestamp-manipulation-attack/
+         */
+        /* solhint-disable-next-line not-rely-on-time */
+        require(commitmentReceipt.commitment.time <= block.timestamp + 15, "too early to claim");
 
         bytes32 txId = keccak256(commitmentReceipt.commitment.signature);
         require(fulfilledTransactions[txId] == false, "can't penalize fulfilled tx");

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/cryptography/ECDSA.sol";
 
 import "./utils/RLPReader.sol";
@@ -9,26 +10,16 @@ import "./utils/RSKAddrValidator.sol";
 import "./interfaces/IRelayHub.sol";
 import "./interfaces/IPenalizer.sol";
 
-contract Penalizer is IPenalizer {
+contract Penalizer is IPenalizer, Ownable {
 
     string public override versionPenalizer = "2.0.1+enveloping.penalizer.ipenalizer";
     
     mapping(bytes32 => bool) public penalizedTransactions;
     mapping(bytes32 => bool) public fulfilledTransactions;
 
-    address private owner;
     address private hub;
 
     using ECDSA for bytes32;
-
-    constructor() public {
-        owner = msg.sender;
-    }
-
-    // temp
-    function getOwner() external view returns (address){
-        return owner;
-    }
 
     function decodeTransaction(bytes memory rawTransaction) private pure returns (Transaction memory transaction) {
         (transaction.nonce,
@@ -45,12 +36,7 @@ contract Penalizer is IPenalizer {
         _;
     }
 
-    modifier onlyOwner() {
-        require(msg.sender == owner, "Not owner");
-        _;
-    }
-
-    function setHub(address relayHub) public override onlyOwner() {
+    function setHub(address relayHub) public override onlyOwner{
         hub = relayHub;
     }
 

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -101,13 +101,13 @@ contract Penalizer is IPenalizer, Ownable {
     }
 
     modifier relayHubOnly() {
-        require(msg.sender == hub, "Unknown relay hub");
+        require(msg.sender == hub, "Unknown Relay Hub");
         _;
     }
 
     function fulfill(bytes memory txSignature) external override relayHubOnly() {
         bytes32 txId = keccak256(txSignature);
-        require(!fulfilledTransactions[txId], "tx already fulfilled");
+        require(!fulfilledTransactions[txId], "Transaction already fulfilled");
         fulfilledTransactions[txId] = true;
     }
 
@@ -116,6 +116,7 @@ contract Penalizer is IPenalizer, Ownable {
     }
 
     function claim(CommitmentReceipt calldata commitmentReceipt) external override {
+        require(hub != address(0), "Relay Hub not set");
 
         // check if the commitment has enabled qos
         require(commitmentReceipt.commitment.enableQos, "This commitment has not enabled QOS");

--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -183,6 +183,11 @@ contract RelayHub is IRelayHub {
                 )
             }
         }
+
+        if (deployRequest.request.enableQos == true){
+            (bool success, ) = penalizer.call(abi.encodeWithSignature("fulfill(bytes)", signature));
+            require(success, "Penalizer fulfill call failed");
+        }
     }
 
     function relayCall(
@@ -243,8 +248,10 @@ contract RelayHub is IRelayHub {
             );
         }
 
-        (bool success, ) = penalizer.call(abi.encodeWithSignature("fulfill(bytes)", signature));
-        require(success, "Penalizer fulfill call failed");
+        if (relayRequest.request.enableQos == true){
+            (bool success, ) = penalizer.call(abi.encodeWithSignature("fulfill(bytes)", signature));
+            require(success, "Penalizer fulfill call failed");
+        }
     }
 
     modifier penalizerOnly() {

--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -24,6 +24,8 @@ contract RelayHub is IRelayHub {
     address public override penalizer;
 
     string public override versionHub = "2.0.1+enveloping.hub.irelayhub";
+    // bytes4(keccak256("fulfill(bytes32)"))
+    bytes4 private constant FULFILL_SELECTOR = 0x5508ff94;
 
     // maps relay worker's address to its manager's address
     mapping(address => bytes32) public override workerToManager;
@@ -144,6 +146,9 @@ contract RelayHub is IRelayHub {
         EnvelopingTypes.DeployRequest calldata deployRequest,
         bytes calldata signature
     ) external override {
+        /* statement originally present in the GSN repo; 
+         * we left it here because of a small gas improvement noticed on tests execution.
+         */
         (signature);
 
         bytes32 managerEntry = workerToManager[msg.sender];
@@ -185,7 +190,8 @@ contract RelayHub is IRelayHub {
         }
 
         if (deployRequest.request.enableQos == true){
-            (bool success, ) = penalizer.call(abi.encodeWithSignature("fulfill(bytes)", signature));
+            bytes32 signatureHash = keccak256(signature);
+            (bool success, ) = penalizer.call(abi.encodeWithSelector(FULFILL_SELECTOR, signatureHash));
             require(success, "Penalizer fulfill call failed");
         }
     }
@@ -194,6 +200,10 @@ contract RelayHub is IRelayHub {
         EnvelopingTypes.RelayRequest calldata relayRequest,
         bytes calldata signature
     ) external override returns (bool destinationCallSuccess){
+        /* statement originally present in the GSN repo; 
+         * we left it here because of a small gas improvement noticed on tests execution.
+         */
+        (signature);
         require(msg.sender == tx.origin, "RelayWorker cannot be a contract");
         require(
             msg.sender == relayRequest.relayData.relayWorker,
@@ -249,7 +259,8 @@ contract RelayHub is IRelayHub {
         }
 
         if (relayRequest.request.enableQos == true){
-            (bool success, ) = penalizer.call(abi.encodeWithSignature("fulfill(bytes)", signature));
+            bytes32 signatureHash = keccak256(signature);
+            (bool success, ) = penalizer.call(abi.encodeWithSelector(FULFILL_SELECTOR, signatureHash));
             require(success, "Penalizer fulfill call failed");
         }
     }

--- a/contracts/factory/CustomSmartWalletFactory.sol
+++ b/contracts/factory/CustomSmartWalletFactory.sol
@@ -188,7 +188,6 @@ contract CustomSmartWalletFactory is ICustomSmartWalletFactory {
                 tx.origin,
                 req.tokenAmount,
                 req.tokenGas,
-                req.enableQos,
                 req.data
             )
         );
@@ -279,7 +278,7 @@ contract CustomSmartWalletFactory is ICustomSmartWalletFactory {
         return
             abi.encodePacked(
                 keccak256(
-                    "RelayRequest(address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,uint256 enableQos,bool index,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"
+                    "RelayRequest(address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,uint256 index,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"
                 ),
                 abi.encode(
                     req.relayHub,
@@ -291,7 +290,6 @@ contract CustomSmartWalletFactory is ICustomSmartWalletFactory {
                     req.nonce,
                     req.tokenAmount,
                     req.tokenGas,
-                    req.enableQos,
                     req.index,
                     keccak256(req.data)
                 ),

--- a/contracts/factory/CustomSmartWalletFactory.sol
+++ b/contracts/factory/CustomSmartWalletFactory.sol
@@ -188,6 +188,7 @@ contract CustomSmartWalletFactory is ICustomSmartWalletFactory {
                 tx.origin,
                 req.tokenAmount,
                 req.tokenGas,
+                req.enableQos,
                 req.data
             )
         );
@@ -278,7 +279,7 @@ contract CustomSmartWalletFactory is ICustomSmartWalletFactory {
         return
             abi.encodePacked(
                 keccak256(
-                    "RelayRequest(address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,uint256 index,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"
+                    "RelayRequest(address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bool enableQos,uint256 index,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"
                 ),
                 abi.encode(
                     req.relayHub,
@@ -290,6 +291,7 @@ contract CustomSmartWalletFactory is ICustomSmartWalletFactory {
                     req.nonce,
                     req.tokenAmount,
                     req.tokenGas,
+                    req.enableQos,
                     req.index,
                     keccak256(req.data)
                 ),

--- a/contracts/factory/CustomSmartWalletFactory.sol
+++ b/contracts/factory/CustomSmartWalletFactory.sol
@@ -188,7 +188,6 @@ contract CustomSmartWalletFactory is ICustomSmartWalletFactory {
                 tx.origin,
                 req.tokenAmount,
                 req.tokenGas,
-                req.enableQos,
                 req.data
             )
         );

--- a/contracts/factory/CustomSmartWalletFactory.sol
+++ b/contracts/factory/CustomSmartWalletFactory.sol
@@ -188,6 +188,7 @@ contract CustomSmartWalletFactory is ICustomSmartWalletFactory {
                 tx.origin,
                 req.tokenAmount,
                 req.tokenGas,
+                req.enableQos,
                 req.data
             )
         );
@@ -278,7 +279,7 @@ contract CustomSmartWalletFactory is ICustomSmartWalletFactory {
         return
             abi.encodePacked(
                 keccak256(
-                    "RelayRequest(address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,uint256 index,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"
+                    "RelayRequest(address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,uint256 enableQos,bool index,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"
                 ),
                 abi.encode(
                     req.relayHub,
@@ -290,6 +291,7 @@ contract CustomSmartWalletFactory is ICustomSmartWalletFactory {
                     req.nonce,
                     req.tokenAmount,
                     req.tokenGas,
+                    req.enableQos,
                     req.index,
                     keccak256(req.data)
                 ),

--- a/contracts/factory/SmartWalletFactory.sol
+++ b/contracts/factory/SmartWalletFactory.sol
@@ -161,8 +161,7 @@ contract SmartWalletFactory is ISmartWalletFactory {
             req.tokenContract,
             tx.origin,
             req.tokenAmount,
-            req.tokenGas,
-            req.enableQos
+            req.tokenGas
         ));
     }
 
@@ -240,7 +239,7 @@ contract SmartWalletFactory is ISmartWalletFactory {
     ) public pure returns (bytes memory) {
         return
             abi.encodePacked(
-                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,uint256 enableQos,bool index,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"),
+                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,uint256 index,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"),
                 abi.encode(
                     req.relayHub,
                     req.from,
@@ -251,7 +250,6 @@ contract SmartWalletFactory is ISmartWalletFactory {
                     req.nonce,
                     req.tokenAmount,
                     req.tokenGas,
-                    req.enableQos,
                     req.index,
                     keccak256(req.data)    
                 ),

--- a/contracts/factory/SmartWalletFactory.sol
+++ b/contracts/factory/SmartWalletFactory.sol
@@ -161,8 +161,7 @@ contract SmartWalletFactory is ISmartWalletFactory {
             req.tokenContract,
             tx.origin,
             req.tokenAmount,
-            req.tokenGas,
-            req.enableQos
+            req.tokenGas
         ));
     }
 

--- a/contracts/factory/SmartWalletFactory.sol
+++ b/contracts/factory/SmartWalletFactory.sol
@@ -161,7 +161,8 @@ contract SmartWalletFactory is ISmartWalletFactory {
             req.tokenContract,
             tx.origin,
             req.tokenAmount,
-            req.tokenGas
+            req.tokenGas,
+            req.enableQos
         ));
     }
 
@@ -239,7 +240,7 @@ contract SmartWalletFactory is ISmartWalletFactory {
     ) public pure returns (bytes memory) {
         return
             abi.encodePacked(
-                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,uint256 index,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"),
+                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bool enableQos,uint256 index,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"),
                 abi.encode(
                     req.relayHub,
                     req.from,
@@ -250,6 +251,7 @@ contract SmartWalletFactory is ISmartWalletFactory {
                     req.nonce,
                     req.tokenAmount,
                     req.tokenGas,
+                    req.enableQos,
                     req.index,
                     keccak256(req.data)    
                 ),

--- a/contracts/factory/SmartWalletFactory.sol
+++ b/contracts/factory/SmartWalletFactory.sol
@@ -161,7 +161,8 @@ contract SmartWalletFactory is ISmartWalletFactory {
             req.tokenContract,
             tx.origin,
             req.tokenAmount,
-            req.tokenGas
+            req.tokenGas,
+            req.enableQos
         ));
     }
 
@@ -239,7 +240,7 @@ contract SmartWalletFactory is ISmartWalletFactory {
     ) public pure returns (bytes memory) {
         return
             abi.encodePacked(
-                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,uint256 index,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"),
+                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,uint256 enableQos,bool index,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"),
                 abi.encode(
                     req.relayHub,
                     req.from,
@@ -250,6 +251,7 @@ contract SmartWalletFactory is ISmartWalletFactory {
                     req.nonce,
                     req.tokenAmount,
                     req.tokenGas,
+                    req.enableQos,
                     req.index,
                     keccak256(req.data)    
                 ),

--- a/contracts/interfaces/IForwarder.sol
+++ b/contracts/interfaces/IForwarder.sol
@@ -14,6 +14,7 @@ interface IForwarder {
         uint256 nonce;
         uint256 tokenAmount;
         uint256 tokenGas;
+        bool enableQos;
         bytes data;
     }
 
@@ -28,6 +29,7 @@ interface IForwarder {
         uint256 tokenAmount;
         uint256 tokenGas;
         uint256 index; // only used in SmartWallet deploy requests
+        bool enableQos;
         bytes data;
     }
 

--- a/contracts/interfaces/IForwarder.sol
+++ b/contracts/interfaces/IForwarder.sol
@@ -28,8 +28,8 @@ interface IForwarder {
         uint256 nonce;
         uint256 tokenAmount;
         uint256 tokenGas;
-        uint256 index; // only used in SmartWallet deploy requests
         bool enableQos;
+        uint256 index; // only used in SmartWallet deploy requests
         bytes data;
     }
 

--- a/contracts/interfaces/IPenalizer.sol
+++ b/contracts/interfaces/IPenalizer.sol
@@ -29,7 +29,7 @@ interface IPenalizer {
 
     function getHub() external view returns (address);
 
-    function fulfill(bytes calldata txSignature) external;
+    function fulfill(bytes32 txhash) external;
 
     function fulfilled(bytes calldata txSignature) external view returns (bool);
 

--- a/contracts/interfaces/IPenalizer.sol
+++ b/contracts/interfaces/IPenalizer.sol
@@ -34,19 +34,19 @@ interface IPenalizer {
     function fulfilled(bytes calldata txSignature) external view returns (bool);
 
     struct CommitmentReceipt {
+        address workerAddress;
         Commitment commitment;
         bytes workerSignature;
-        address workerAddress;
     }
 
     struct Commitment {
         uint256 time;
         address from;
         address to;
-        bytes data;
         address relayHubAddress;
         address relayWorker;
         bool enableQos;
+        bytes data;
         bytes signature;
     }
 

--- a/contracts/interfaces/IPenalizer.sol
+++ b/contracts/interfaces/IPenalizer.sol
@@ -29,7 +29,7 @@ interface IPenalizer {
 
     function getHub() external view returns (address);
 
-    function fulfill(bytes memory txSignature) external;
+    function fulfill(bytes calldata txSignature) external;
 
     function fulfilled(bytes calldata txSignature) external view returns (bool);
 

--- a/contracts/interfaces/IPenalizer.sol
+++ b/contracts/interfaces/IPenalizer.sol
@@ -20,12 +20,12 @@ interface IPenalizer {
         bytes calldata signature1,
         bytes calldata unsignedTx2,
         bytes calldata signature2,
-        IRelayHub _hub
+        IRelayHub relayHub
     ) external;
 
     function versionPenalizer() external view returns (string memory);
 
-    function setHub(address _hub) external;
+    function setHub(address relayHub) external;
 
     function getHub() external view returns (address);
 

--- a/contracts/interfaces/IPenalizer.sol
+++ b/contracts/interfaces/IPenalizer.sol
@@ -20,12 +20,14 @@ interface IPenalizer {
         bytes calldata signature1,
         bytes calldata unsignedTx2,
         bytes calldata signature2,
-        IRelayHub hub
+        IRelayHub _hub
     ) external;
 
     function versionPenalizer() external view returns (string memory);
 
-    function setupHub(address _hubAddress) external;
+    function setHub(address _hub) external;
+
+    function getHub() external view returns (address);
 
     function fulfill(bytes memory txSignature) external;
 

--- a/contracts/interfaces/IPenalizer.sol
+++ b/contracts/interfaces/IPenalizer.sol
@@ -45,6 +45,7 @@ interface IPenalizer {
         address relayHubAddress;
         address relayWorker;
         bool enabledQos;
+        bytes signature;
     }
 
     function claim(CommitmentReceipt calldata commitmentReceipt) external;

--- a/contracts/interfaces/IPenalizer.sol
+++ b/contracts/interfaces/IPenalizer.sol
@@ -14,20 +14,17 @@ interface IPenalizer {
         uint256 value;
         bytes data;
     }
+    
+    function relayHub() external view returns(address);
+
+    function versionPenalizer() external view returns (string memory);
 
     function penalizeRepeatedNonce(
         bytes calldata unsignedTx1,
         bytes calldata signature1,
         bytes calldata unsignedTx2,
-        bytes calldata signature2,
-        IRelayHub relayHub
+        bytes calldata signature2
     ) external;
-
-    function versionPenalizer() external view returns (string memory);
-
-    function setHub(address relayHub) external;
-
-    function getHub() external view returns (address);
 
     function fulfill(bytes32 txhash) external;
 

--- a/contracts/interfaces/IPenalizer.sol
+++ b/contracts/interfaces/IPenalizer.sol
@@ -44,7 +44,7 @@ interface IPenalizer {
         bytes data;
         address relayHubAddress;
         address relayWorker;
-        bool enabledQos;
+        bool enableQos;
         bytes signature;
     }
 

--- a/contracts/interfaces/IPenalizer.sol
+++ b/contracts/interfaces/IPenalizer.sol
@@ -25,9 +25,7 @@ interface IPenalizer {
 
     function versionPenalizer() external view returns (string memory);
 
-    function fulfill(
-        bytes memory txSignature
-    ) external;
+    function fulfill(bytes memory txSignature, IRelayHub hub) external;
 
     function fulfilled(bytes calldata txSignature) external view returns (bool);
 

--- a/contracts/interfaces/IPenalizer.sol
+++ b/contracts/interfaces/IPenalizer.sol
@@ -29,7 +29,7 @@ interface IPenalizer {
         bytes memory txSignature
     ) external;
 
-    function fulfilled(bytes calldata signature) external view returns (bool);
+    function fulfilled(bytes calldata txSignature) external view returns (bool);
 
     struct CommitmentReceipt {
         Commitment commitment;

--- a/contracts/interfaces/IPenalizer.sol
+++ b/contracts/interfaces/IPenalizer.sol
@@ -25,7 +25,9 @@ interface IPenalizer {
 
     function versionPenalizer() external view returns (string memory);
 
-    function fulfill(bytes memory txSignature, IRelayHub hub) external;
+    function setupHub(address _hubAddress) external;
+
+    function fulfill(bytes memory txSignature) external;
 
     function fulfilled(bytes calldata txSignature) external view returns (bool);
 

--- a/contracts/interfaces/IRelayHub.sol
+++ b/contracts/interfaces/IRelayHub.sol
@@ -89,6 +89,8 @@ interface IRelayHub {
     
     function penalize(address relayWorker, address payable beneficiary) external;
 
+    function setPenalizer(address _penalizer) external;
+
     /* getters */
     function penalizer() external view returns(address);
 

--- a/contracts/smartwallet/CustomSmartWallet.sol
+++ b/contracts/smartwallet/CustomSmartWallet.sol
@@ -220,7 +220,7 @@ contract CustomSmartWallet is IForwarder {
     ) private pure returns (bytes memory) {
         return
             abi.encodePacked(
-                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bytes enableQos,bool data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"), //requestTypeHash,
+                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"), //requestTypeHash,
                 abi.encode(
                     req.relayHub,
                     req.from,
@@ -231,7 +231,6 @@ contract CustomSmartWallet is IForwarder {
                     req.nonce,
                     req.tokenAmount,
                     req.tokenGas,
-                    req.enableQos,
                     keccak256(req.data)
                 ),
                 suffixData

--- a/contracts/smartwallet/CustomSmartWallet.sol
+++ b/contracts/smartwallet/CustomSmartWallet.sol
@@ -220,7 +220,7 @@ contract CustomSmartWallet is IForwarder {
     ) private pure returns (bytes memory) {
         return
             abi.encodePacked(
-                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"), //requestTypeHash,
+                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bytes enableQos,bool data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"), //requestTypeHash,
                 abi.encode(
                     req.relayHub,
                     req.from,
@@ -231,6 +231,7 @@ contract CustomSmartWallet is IForwarder {
                     req.nonce,
                     req.tokenAmount,
                     req.tokenGas,
+                    req.enableQos,
                     keccak256(req.data)
                 ),
                 suffixData

--- a/contracts/smartwallet/CustomSmartWallet.sol
+++ b/contracts/smartwallet/CustomSmartWallet.sol
@@ -220,7 +220,7 @@ contract CustomSmartWallet is IForwarder {
     ) private pure returns (bytes memory) {
         return
             abi.encodePacked(
-                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"), //requestTypeHash,
+                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bool enableQos,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"), //requestTypeHash,
                 abi.encode(
                     req.relayHub,
                     req.from,
@@ -231,6 +231,7 @@ contract CustomSmartWallet is IForwarder {
                     req.nonce,
                     req.tokenAmount,
                     req.tokenGas,
+                    req.enableQos,
                     keccak256(req.data)
                 ),
                 suffixData

--- a/contracts/smartwallet/SmartWallet.sol
+++ b/contracts/smartwallet/SmartWallet.sol
@@ -199,7 +199,7 @@ contract SmartWallet is IForwarder {
     ) private pure returns (bytes memory) {
         return
             abi.encodePacked(
-                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"), //requestTypeHash,
+                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bool enableQos,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"), //requestTypeHash,
                 abi.encode(
                     req.relayHub,
                     req.from,
@@ -209,7 +209,8 @@ contract SmartWallet is IForwarder {
                     req.gas,
                     req.nonce,
                     req.tokenAmount,
-                    req.tokenGas,              
+                    req.tokenGas,
+                    req.enableQos,              
                     keccak256(req.data)
                 ),
                 suffixData

--- a/contracts/smartwallet/SmartWallet.sol
+++ b/contracts/smartwallet/SmartWallet.sol
@@ -199,7 +199,7 @@ contract SmartWallet is IForwarder {
     ) private pure returns (bytes memory) {
         return
             abi.encodePacked(
-                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bytes enableQos,bool data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"), //requestTypeHash,
+                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"), //requestTypeHash,
                 abi.encode(
                     req.relayHub,
                     req.from,
@@ -209,8 +209,7 @@ contract SmartWallet is IForwarder {
                     req.gas,
                     req.nonce,
                     req.tokenAmount,
-                    req.tokenGas,
-                    req.enableQos,              
+                    req.tokenGas,              
                     keccak256(req.data)
                 ),
                 suffixData

--- a/contracts/smartwallet/SmartWallet.sol
+++ b/contracts/smartwallet/SmartWallet.sol
@@ -199,7 +199,7 @@ contract SmartWallet is IForwarder {
     ) private pure returns (bytes memory) {
         return
             abi.encodePacked(
-                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bytes data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"), //requestTypeHash,
+                keccak256("RelayRequest(address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bytes enableQos,bool data,RelayData relayData)RelayData(uint256 gasPrice,bytes32 domainSeparator,address relayWorker,address callForwarder,address callVerifier)"), //requestTypeHash,
                 abi.encode(
                     req.relayHub,
                     req.from,
@@ -209,7 +209,8 @@ contract SmartWallet is IForwarder {
                     req.gas,
                     req.nonce,
                     req.tokenAmount,
-                    req.tokenGas,              
+                    req.tokenGas,
+                    req.enableQos,              
                     keccak256(req.data)
                 ),
                 suffixData

--- a/contracts/test/TestUtil.sol
+++ b/contracts/test/TestUtil.sol
@@ -78,6 +78,7 @@ contract TestUtil {
             req.request.nonce,
             req.request.tokenAmount,
             req.request.tokenGas,
+            req.request.enableQos,
             req.request.data
         );
         suffixData = Eip712Library.hashRelayData(req.relayData);

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -19,8 +19,8 @@ module.exports = async function (deployer) {
   await deployer.deploy(Penalizer)
   await deployer.deploy(RelayHub, Penalizer.address, 4, 4, 4, 4)
 
-  const penalizer = await new web3.eth.Contract(Penalizer.abi, Penalizer.address)
-  await penalizer.methods.setHub(RelayHub.address).send({ from: await penalizer.methods.owner().call() })
+  const relayHub = await new web3.eth.Contract(RelayHub.abi, RelayHub.address)
+  await relayHub.methods.setPenalizer(Penalizer.address).send({ from: await relayHub.methods.owner().call() })
 
   await deployer.deploy(SmartWallet)
   await deployer.deploy(SmartWalletFactory, SmartWallet.address)

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -20,7 +20,7 @@ module.exports = async function (deployer) {
   await deployer.deploy(RelayHub, Penalizer.address, 4, 4, 4, 4)
 
   const penalizer = await new web3.eth.Contract(Penalizer.abi, Penalizer.address)
-  await penalizer.methods.setHub(RelayHub.address).send({from: await penalizer.methods.owner().call()})
+  await penalizer.methods.setHub(RelayHub.address).send({ from: await penalizer.methods.owner().call() })
 
   await deployer.deploy(SmartWallet)
   await deployer.deploy(SmartWalletFactory, SmartWallet.address)

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -18,6 +18,10 @@ const CustomSmartWalletDeployVerifier = artifacts.require('CustomSmartWalletDepl
 module.exports = async function (deployer) {
   await deployer.deploy(Penalizer)
   await deployer.deploy(RelayHub, Penalizer.address, 4, 4, 4, 4)
+
+  const penalizer = await new web3.eth.Contract(Penalizer.abi, Penalizer.address)
+  await penalizer.methods.setupHub(RelayHub.address).call()
+
   await deployer.deploy(SmartWallet)
   await deployer.deploy(SmartWalletFactory, SmartWallet.address)
   await deployer.deploy(DeployVerifier, SmartWalletFactory.address)

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -21,7 +21,7 @@ module.exports = async function (deployer) {
 
   const penalizer = await new web3.eth.Contract(Penalizer.abi, Penalizer.address)
   const penalizerOwner = await penalizer.methods.getOwner().call() // temp
-  await penalizer.methods.setHub(RelayHub.address).call({ from: penalizerOwner })
+  await penalizer.methods.setHub({'relayHub': RelayHub.address}).call({from: penalizerOwner})
 
   await deployer.deploy(SmartWallet)
   await deployer.deploy(SmartWalletFactory, SmartWallet.address)

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -20,7 +20,8 @@ module.exports = async function (deployer) {
   await deployer.deploy(RelayHub, Penalizer.address, 4, 4, 4, 4)
 
   const penalizer = await new web3.eth.Contract(Penalizer.abi, Penalizer.address)
-  await penalizer.methods.setupHub(RelayHub.address).call()
+  const penalizerOwner = await penalizer.methods.viewOwner().call() // temp
+  await penalizer.methods.setupHub(RelayHub.address).call({from: penalizerOwner})
 
   await deployer.deploy(SmartWallet)
   await deployer.deploy(SmartWalletFactory, SmartWallet.address)

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -20,8 +20,9 @@ module.exports = async function (deployer) {
   await deployer.deploy(RelayHub, Penalizer.address, 4, 4, 4, 4)
 
   const penalizer = await new web3.eth.Contract(Penalizer.abi, Penalizer.address)
-  const penalizerOwner = await penalizer.methods.getOwner().call() // temp
-  await penalizer.methods.setHub(RelayHub.address).call({from: penalizerOwner})
+  const penalizerOwner = await penalizer.methods.owner().call()
+  await penalizer.methods.setHub(RelayHub.address).send({from: penalizerOwner})
+  const hub = await penalizer.methods.getHub().call()
 
   await deployer.deploy(SmartWallet)
   await deployer.deploy(SmartWalletFactory, SmartWallet.address)

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -22,7 +22,6 @@ module.exports = async function (deployer) {
   const penalizer = await new web3.eth.Contract(Penalizer.abi, Penalizer.address)
   const penalizerOwner = await penalizer.methods.owner().call()
   await penalizer.methods.setHub(RelayHub.address).send({from: penalizerOwner})
-  const hub = await penalizer.methods.getHub().call()
 
   await deployer.deploy(SmartWallet)
   await deployer.deploy(SmartWalletFactory, SmartWallet.address)

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -19,8 +19,8 @@ module.exports = async function (deployer) {
   await deployer.deploy(Penalizer)
   await deployer.deploy(RelayHub, Penalizer.address, 4, 4, 4, 4)
 
-  const relayHub = await new web3.eth.Contract(RelayHub.abi, RelayHub.address)
-  await relayHub.methods.setPenalizer(Penalizer.address).send({ from: await relayHub.methods.owner().call() })
+  const penalizer = await new web3.eth.Contract(Penalizer.abi, Penalizer.address)
+  await penalizer.methods.setHub(RelayHub.address).send({ from: await penalizer.methods.owner().call() })
 
   await deployer.deploy(SmartWallet)
   await deployer.deploy(SmartWalletFactory, SmartWallet.address)

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -21,7 +21,7 @@ module.exports = async function (deployer) {
 
   const penalizer = await new web3.eth.Contract(Penalizer.abi, Penalizer.address)
   const penalizerOwner = await penalizer.methods.getOwner().call() // temp
-  await penalizer.methods.setHub({'relayHub': RelayHub.address}).call({from: penalizerOwner})
+  await penalizer.methods.setHub(RelayHub.address).call({from: penalizerOwner})
 
   await deployer.deploy(SmartWallet)
   await deployer.deploy(SmartWalletFactory, SmartWallet.address)

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -20,8 +20,7 @@ module.exports = async function (deployer) {
   await deployer.deploy(RelayHub, Penalizer.address, 4, 4, 4, 4)
 
   const penalizer = await new web3.eth.Contract(Penalizer.abi, Penalizer.address)
-  const penalizerOwner = await penalizer.methods.owner().call()
-  await penalizer.methods.setHub(RelayHub.address).send({ from: penalizerOwner })
+  await penalizer.methods.setHub(RelayHub.address).send({from: await penalizer.methods.owner().call()})
 
   await deployer.deploy(SmartWallet)
   await deployer.deploy(SmartWalletFactory, SmartWallet.address)

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -20,8 +20,8 @@ module.exports = async function (deployer) {
   await deployer.deploy(RelayHub, Penalizer.address, 4, 4, 4, 4)
 
   const penalizer = await new web3.eth.Contract(Penalizer.abi, Penalizer.address)
-  const penalizerOwner = await penalizer.methods.viewOwner().call() // temp
-  await penalizer.methods.setupHub(RelayHub.address).call({ from: penalizerOwner })
+  const penalizerOwner = await penalizer.methods.getOwner().call() // temp
+  await penalizer.methods.setHub(RelayHub.address).call({ from: penalizerOwner })
 
   await deployer.deploy(SmartWallet)
   await deployer.deploy(SmartWalletFactory, SmartWallet.address)

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -16,11 +16,11 @@ const CustomSmartWalletFactory = artifacts.require('CustomSmartWalletFactory')
 const CustomSmartWalletDeployVerifier = artifacts.require('CustomSmartWalletDeployVerifier')
 
 module.exports = async function (deployer) {
-  await deployer.deploy(Penalizer)
-  await deployer.deploy(RelayHub, Penalizer.address, 4, 4, 4, 4)
+  await deployer.deploy(RelayHub, 4, 4, 4, 4)
+  await deployer.deploy(Penalizer, RelayHub.address)
 
-  const penalizer = await new web3.eth.Contract(Penalizer.abi, Penalizer.address)
-  await penalizer.methods.setHub(RelayHub.address).send({ from: await penalizer.methods.owner().call() })
+  const relayHub = await new web3.eth.Contract(RelayHub.abi, RelayHub.address)
+  await relayHub.methods.setPenalizer(Penalizer.address).send({ from: await relayHub.methods.owner().call() })
 
   await deployer.deploy(SmartWallet)
   await deployer.deploy(SmartWalletFactory, SmartWallet.address)
@@ -44,8 +44,8 @@ module.exports = async function (deployer) {
   console.log('|===================================|============================================|')
   console.log('| Contract                          | Address                                    |')
   console.log('|===================================|============================================|')
-  console.log(`| Penalizer                         | ${Penalizer.address} |`)
   console.log(`| RelayHub                          | ${RelayHub.address} |`)
+  console.log(`| Penalizer                         | ${Penalizer.address} |`)
   console.log('| Smart Wallet Contracts ========================================================|')
   console.log(`| SmartWallet                       | ${SmartWallet.address} |`)
   console.log(`| SmartWalletFactory                | ${SmartWalletFactory.address} |`)

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -21,7 +21,7 @@ module.exports = async function (deployer) {
 
   const penalizer = await new web3.eth.Contract(Penalizer.abi, Penalizer.address)
   const penalizerOwner = await penalizer.methods.viewOwner().call() // temp
-  await penalizer.methods.setupHub(RelayHub.address).call({from: penalizerOwner})
+  await penalizer.methods.setupHub(RelayHub.address).call({ from: penalizerOwner })
 
   await deployer.deploy(SmartWallet)
   await deployer.deploy(SmartWalletFactory, SmartWallet.address)

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -21,7 +21,7 @@ module.exports = async function (deployer) {
 
   const penalizer = await new web3.eth.Contract(Penalizer.abi, Penalizer.address)
   const penalizerOwner = await penalizer.methods.owner().call()
-  await penalizer.methods.setHub(RelayHub.address).send({from: penalizerOwner})
+  await penalizer.methods.setHub(RelayHub.address).send({ from: penalizerOwner })
 
   await deployer.deploy(SmartWallet)
   await deployer.deploy(SmartWalletFactory, SmartWallet.address)

--- a/rsknode/Dockerfile
+++ b/rsknode/Dockerfile
@@ -9,7 +9,7 @@ RUN gpg --keyserver https://secchannel.rsk.co/release.asc --recv-keys 1A92D89421
 RUN gpg --finger 1A92D8942171AFA951A857365DECF4415E3B8FA4
 
 ARG rskj_codename=SNAPSHOT
-ARG rskj_version=3.1.0
+ARG rskj_version=3.2.0
 ARG working_branch=master
 
 RUN git clone --single-branch --depth 1 --branch "${working_branch}" https://github.com/rsksmart/rskj.git /code/rskj
@@ -24,7 +24,7 @@ RUN ./gradlew --no-daemon clean build -x test
 FROM openjdk:8-jdk-slim-buster
 
 ARG rskj_codename=SNAPSHOT
-ARG rskj_version=3.1.0
+ARG rskj_version=3.2.0
 
 WORKDIR /usr/local/rskj
 COPY --from=build /code/rskj/rskj-core/build/libs/rskj-core-${rskj_version}-${rskj_codename}-all.jar ./rsk.jar

--- a/rsknode/Dockerfile
+++ b/rsknode/Dockerfile
@@ -9,7 +9,7 @@ RUN gpg --keyserver https://secchannel.rsk.co/release.asc --recv-keys 1A92D89421
 RUN gpg --finger 1A92D8942171AFA951A857365DECF4415E3B8FA4
 
 ARG rskj_codename=SNAPSHOT
-ARG rskj_version=3.0.0
+ARG rskj_version=3.1.0
 ARG working_branch=master
 
 RUN git clone --single-branch --depth 1 --branch "${working_branch}" https://github.com/rsksmart/rskj.git /code/rskj
@@ -24,7 +24,7 @@ RUN ./gradlew --no-daemon clean build -x test
 FROM openjdk:8-jdk-slim-buster
 
 ARG rskj_codename=SNAPSHOT
-ARG rskj_version=3.0.0
+ARG rskj_version=3.1.0
 
 WORKDIR /usr/local/rskj
 COPY --from=build /code/rskj/rskj-core/build/libs/rskj-core-${rskj_version}-${rskj_codename}-all.jar ./rsk.jar

--- a/rsknode/docker-compose.yml
+++ b/rsknode/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: "."
       args:
         - rskj_codename=SNAPSHOT
-        - rskj_version=3.1.0
+        - rskj_version=3.2.0
         - working_branch=master
     container_name: rsk-node
     image: rskj:latest

--- a/rsknode/docker-compose.yml
+++ b/rsknode/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: "."
       args:
         - rskj_codename=SNAPSHOT
-        - rskj_version=3.0.0
+        - rskj_version=3.1.0
         - working_branch=master
     container_name: rsk-node
     image: rskj:latest

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -103,7 +103,6 @@ run_batch \
     test/TestEnvironment.test.ts \
     test/HttpWrapper.test.ts \
     test/KeyManager.test.ts \
-    test/PaymasterCommitment.test.ts \
     test/WalletFactory.test.ts
 
 # Test_Group_4

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -118,3 +118,6 @@ run_batch test/RelayHub.test.ts
 run_batch test/VersionRegistry.test.ts
 run_batch test/relayclient/RelayProvider.test.ts
 run_batch test/relayclient/RelaySelectionManager.test.ts
+
+# Test_Group_6
+run_batch test/enveloping/EnvelopingArbiter.test.ts

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -75,6 +75,7 @@ set -e
 # Test_Group_1
 run_batch \
     test/RelayHubPenalizations.test.ts \
+    test/penalizer/Penalizer.test.ts \
     test/RelayHubRegistrationsManagement.test.ts \
     test/TxStoreManager.test.ts \
     test/common/VersionManager.test.ts \

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,6 +3,7 @@ run_batch()
 {
 	cid=$(docker run --init --network "$TEST_NETWORK" \
 	    --expose 4444 -p 127.0.0.1:4444:4444 \
+		--expose 4445 -p 127.0.0.1:4445:4445 \
 	    --rm -itd --name enveloping-rskj rsknode --regtest)
 
 	_i=0
@@ -25,6 +26,8 @@ run_batch()
 	done
 
 	docker stop "$cid"
+	# sometimes the container is still running so we need to remove it forcefully
+	docker rm --force enveloping-rskj 2>/dev/null || true
 }
 
 setup_containers()

--- a/scripts/execute-all-tests
+++ b/scripts/execute-all-tests
@@ -36,6 +36,7 @@ function run_batch() {
 # Test_Group_1
 run_batch Test_Group_1 \
     test/RelayHubPenalizations.test.ts \
+    test/penalizer/Penalizer.test.ts \
     test/RelayHubRegistrationsManagement.test.ts \
     test/TxStoreManager.test.ts \
     test/common/VersionManager.test.ts \

--- a/scripts/execute-all-tests
+++ b/scripts/execute-all-tests
@@ -63,7 +63,6 @@ run_batch Test_Group_3 \
     test/TestEnvironment.test.ts \
     test/HttpWrapper.test.ts \
     test/KeyManager.test.ts \
-    test/PaymasterCommitment.test.ts \
     test/WalletFactory.test.ts
 
 # Test_Group_4

--- a/scripts/postpack
+++ b/scripts/postpack
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 #these files were created for packing only (see "prepack")
-for c in RelayProvider RelayClient Configurator TestEnvironment Utils; do
+for c in RelayProvider RelayClient RelayEvents Configurator TestEnvironment Utils; do
   echo del ./$c.ts:
   rm $c.ts
 done

--- a/src/cli/CommandsLogic.ts
+++ b/src/cli/CommandsLogic.ts
@@ -250,8 +250,6 @@ export default class CommandsLogic {
       gasPrice: deployOptions.gasPrice ?? (1e9).toString()
     }
 
-    const penalizer = await this.getContract(Penalizer, {}, deployOptions.penalizerAddress, Object.assign({}, options), deployOptions.skipConfirmation)
-
     const smartWallet = await this.getContract(SmartWallet, {}, deployOptions.smartWalletTemplateAddress, Object.assign({}, options), deployOptions.skipConfirmation)
     const smartWalletFactory = await this.getContract(SmartWalletFactory, {
       arguments: [
@@ -268,12 +266,17 @@ export default class CommandsLogic {
 
     const rInstance = await this.getContract(RelayHub, {
       arguments: [
-        penalizer.options.address,
         deployOptions.relayHubConfiguration.maxWorkerCount,
         deployOptions.relayHubConfiguration.minimumEntryDepositValue,
         deployOptions.relayHubConfiguration.minimumUnstakeDelay,
         deployOptions.relayHubConfiguration.minimumStake]
     }, deployOptions.relayHubAddress, merge({}, options, { gas: 5e6 }), deployOptions.skipConfirmation)
+
+    const penalizer = await this.getContract(Penalizer, {
+      arguments: [
+        rInstance.options.address
+      ]
+    }, deployOptions.penalizerAddress, Object.assign({}, options), deployOptions.skipConfirmation)
 
     const regInstance = await this.getContract(VersionRegistryAbi, {}, deployOptions.registryAddress, Object.assign({}, options), deployOptions.skipConfirmation)
     if (deployOptions.registryHubId != null) {

--- a/src/common/EIP712/ForwardRequest.ts
+++ b/src/common/EIP712/ForwardRequest.ts
@@ -12,7 +12,7 @@ export interface ForwardRequest {
   tokenAmount: IntString
   tokenGas: IntString
   data: PrefixedHexString
-  enabledQos?: BoolString
+  enableQos?: BoolString
 }
 
 export interface DeployRequestStruct {
@@ -27,5 +27,5 @@ export interface DeployRequestStruct {
   tokenGas: IntString
   index: IntString
   data: PrefixedHexString
-  enabledQos?: BoolString
+  enableQos?: BoolString
 }

--- a/src/common/EIP712/ForwardRequest.ts
+++ b/src/common/EIP712/ForwardRequest.ts
@@ -12,7 +12,7 @@ export interface ForwardRequest {
   tokenAmount: IntString
   tokenGas: IntString
   data: PrefixedHexString
-  enableQos?: BoolString
+  enableQos: BoolString
 }
 
 export interface DeployRequestStruct {
@@ -27,5 +27,5 @@ export interface DeployRequestStruct {
   tokenGas: IntString
   index: IntString
   data: PrefixedHexString
-  enableQos?: BoolString
+  enableQos: BoolString
 }

--- a/src/common/EIP712/ForwardRequest.ts
+++ b/src/common/EIP712/ForwardRequest.ts
@@ -1,4 +1,4 @@
-import { Address, BoolString, IntString } from '../../relayclient/types/Aliases'
+import { Address, IntString } from '../../relayclient/types/Aliases'
 import { PrefixedHexString } from 'ethereumjs-tx'
 
 export interface ForwardRequest {

--- a/src/common/EIP712/ForwardRequest.ts
+++ b/src/common/EIP712/ForwardRequest.ts
@@ -11,8 +11,8 @@ export interface ForwardRequest {
   nonce: IntString
   tokenAmount: IntString
   tokenGas: IntString
+  enableQos: boolean
   data: PrefixedHexString
-  enableQos: BoolString
 }
 
 export interface DeployRequestStruct {
@@ -25,7 +25,7 @@ export interface DeployRequestStruct {
   nonce: IntString
   tokenAmount: IntString
   tokenGas: IntString
+  enableQos: boolean
   index: IntString
   data: PrefixedHexString
-  enableQos: BoolString
 }

--- a/src/common/EIP712/TypedRequestData.ts
+++ b/src/common/EIP712/TypedRequestData.ts
@@ -32,7 +32,6 @@ export const ForwardRequestType = [
   { name: 'nonce', type: 'uint256' },
   { name: 'tokenAmount', type: 'uint256' },
   { name: 'tokenGas', type: 'uint256' },
-  { name: 'enableQos', type: 'bool' },
   { name: 'data', type: 'bytes' }
 ]
 
@@ -46,7 +45,6 @@ export const DeployRequestDataType = [
   { name: 'nonce', type: 'uint256' },
   { name: 'tokenAmount', type: 'uint256' },
   { name: 'tokenGas', type: 'uint256' },
-  { name: 'enableQos', type: 'bool' },
   { name: 'index', type: 'uint256' },
   { name: 'data', type: 'bytes' }
 ]
@@ -139,8 +137,8 @@ export class TypedDeployRequestData implements EIP712TypedData {
   }
 }
 
-export const ENVELOPING_PARAMS = 'address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bytes enableQos,bool data'
-export const DEPLOY_PARAMS = 'address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,uint256 enableQos,bool index,bytes data'
+export const ENVELOPING_PARAMS = 'address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bytes data'
+export const DEPLOY_PARAMS = 'address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,uint256 index,bytes data'
 
 export const RequestType = {
   typeName: 'RelayRequest',

--- a/src/common/EIP712/TypedRequestData.ts
+++ b/src/common/EIP712/TypedRequestData.ts
@@ -32,6 +32,7 @@ export const ForwardRequestType = [
   { name: 'nonce', type: 'uint256' },
   { name: 'tokenAmount', type: 'uint256' },
   { name: 'tokenGas', type: 'uint256' },
+  { name: 'enableQos', type: 'bool' },
   { name: 'data', type: 'bytes' }
 ]
 

--- a/src/common/EIP712/TypedRequestData.ts
+++ b/src/common/EIP712/TypedRequestData.ts
@@ -32,6 +32,7 @@ export const ForwardRequestType = [
   { name: 'nonce', type: 'uint256' },
   { name: 'tokenAmount', type: 'uint256' },
   { name: 'tokenGas', type: 'uint256' },
+  { name: 'enableQos', type: 'bool' },
   { name: 'data', type: 'bytes' }
 ]
 
@@ -45,6 +46,7 @@ export const DeployRequestDataType = [
   { name: 'nonce', type: 'uint256' },
   { name: 'tokenAmount', type: 'uint256' },
   { name: 'tokenGas', type: 'uint256' },
+  { name: 'enableQos', type: 'bool' },
   { name: 'index', type: 'uint256' },
   { name: 'data', type: 'bytes' }
 ]
@@ -137,8 +139,8 @@ export class TypedDeployRequestData implements EIP712TypedData {
   }
 }
 
-export const ENVELOPING_PARAMS = 'address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bytes data'
-export const DEPLOY_PARAMS = 'address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,uint256 index,bytes data'
+export const ENVELOPING_PARAMS = 'address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bool enableQos,bytes data'
+export const DEPLOY_PARAMS = 'address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bool enableQos,uint256 index,bytes data'
 
 export const RequestType = {
   typeName: 'RelayRequest',

--- a/src/common/EIP712/TypedRequestData.ts
+++ b/src/common/EIP712/TypedRequestData.ts
@@ -46,6 +46,7 @@ export const DeployRequestDataType = [
   { name: 'nonce', type: 'uint256' },
   { name: 'tokenAmount', type: 'uint256' },
   { name: 'tokenGas', type: 'uint256' },
+  { name: 'enableQos', type: 'bool' },
   { name: 'index', type: 'uint256' },
   { name: 'data', type: 'bytes' }
 ]

--- a/src/common/EIP712/TypedRequestData.ts
+++ b/src/common/EIP712/TypedRequestData.ts
@@ -139,8 +139,8 @@ export class TypedDeployRequestData implements EIP712TypedData {
   }
 }
 
-export const ENVELOPING_PARAMS = 'address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bytes data'
-export const DEPLOY_PARAMS = 'address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,uint256 index,bytes data'
+export const ENVELOPING_PARAMS = 'address relayHub,address from,address to,address tokenContract,uint256 value,uint256 gas,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,bytes enableQos,bool data'
+export const DEPLOY_PARAMS = 'address relayHub,address from,address to,address tokenContract,address recoverer,uint256 value,uint256 nonce,uint256 tokenAmount,uint256 tokenGas,uint256 enableQos,bool index,bytes data'
 
 export const RequestType = {
   typeName: 'RelayRequest',

--- a/src/enveloping/Commitment.ts
+++ b/src/enveloping/Commitment.ts
@@ -44,9 +44,9 @@ export class Commitment {
     this.signature = signature
   }
 
-  public static TypeEncoding = 'commit(uint,address,address,bytes,address,address,bool)'
+  public static encodedFieldTypes = ['uint256', 'address', 'address', 'bytes', 'address', 'address', 'bool']
 
-  orderForEnc (): any[] {
+  encodedFields (): any[] {
     return [
       this.time,
       this.from,
@@ -59,6 +59,6 @@ export class Commitment {
   }
 
   encodeForSign (): PrefixedHexString {
-    return ethers.utils.defaultAbiCoder.encode([Commitment.TypeEncoding], [this.orderForEnc()])
+    return ethers.utils.defaultAbiCoder.encode(Commitment.encodedFieldTypes, this.encodedFields())
   }
 }

--- a/src/enveloping/Commitment.ts
+++ b/src/enveloping/Commitment.ts
@@ -6,7 +6,7 @@ export interface CommitmentResponse {
   signedTx: PrefixedHexString
   signedReceipt?: CommitmentReceipt
   transactionHash: PrefixedHexString
-} 
+}
 
 export interface CommitmentReceipt {
   commitment: Commitment

--- a/src/enveloping/Commitment.ts
+++ b/src/enveloping/Commitment.ts
@@ -21,7 +21,7 @@ export class Commitment {
   data: PrefixedHexString
   relayHubAddress: Address
   relayWorker: Address
-  enableQos: BoolString
+  enableQos: boolean
   signature: PrefixedHexString
 
   constructor (
@@ -31,7 +31,7 @@ export class Commitment {
     data: PrefixedHexString,
     relayHubAddress: Address,
     relayWorker: Address,
-    enableQos: BoolString | undefined,
+    enableQos: boolean,
     signature: PrefixedHexString
   ) {
     this.time = time
@@ -40,7 +40,7 @@ export class Commitment {
     this.data = data
     this.relayHubAddress = relayHubAddress
     this.relayWorker = relayWorker
-    this.enableQos = enableQos === 'true' ? 'true' : 'false'
+    this.enableQos = enableQos
     this.signature = signature
   }
 

--- a/src/enveloping/Commitment.ts
+++ b/src/enveloping/Commitment.ts
@@ -1,4 +1,4 @@
-import { Address, BoolString } from '../relayclient/types/Aliases'
+import { Address } from '../relayclient/types/Aliases'
 import { PrefixedHexString } from 'ethereumjs-tx'
 import { ethers } from 'ethers'
 

--- a/src/enveloping/Commitment.ts
+++ b/src/enveloping/Commitment.ts
@@ -2,16 +2,16 @@ import { Address } from '../relayclient/types/Aliases'
 import { PrefixedHexString } from 'ethereumjs-tx'
 import { ethers } from 'ethers'
 
-export interface CommitmentReceipt {
-  commitment: Commitment
-  workerSignature: PrefixedHexString
-  workerAddress: Address
-}
-
 export interface CommitmentResponse {
   signedTx: PrefixedHexString
   signedReceipt?: CommitmentReceipt
   transactionHash: PrefixedHexString
+}
+
+export interface CommitmentReceipt {
+  commitment: Commitment
+  workerSignature: PrefixedHexString
+  workerAddress: Address
 }
 
 export class Commitment {

--- a/src/enveloping/Commitment.ts
+++ b/src/enveloping/Commitment.ts
@@ -6,7 +6,7 @@ export interface CommitmentResponse {
   signedTx: PrefixedHexString
   signedReceipt?: CommitmentReceipt
   transactionHash: PrefixedHexString
-}
+} 
 
 export interface CommitmentReceipt {
   commitment: Commitment

--- a/src/enveloping/Commitment.ts
+++ b/src/enveloping/Commitment.ts
@@ -58,7 +58,7 @@ export class Commitment {
     ]
   }
 
-  encodeForSign (relayHubAddress: Address): PrefixedHexString {
-    return ethers.utils.defaultAbiCoder.encode([Commitment.TypeEncoding, 'address'], [this.orderForEnc(), relayHubAddress])
+  encodeForSign (): PrefixedHexString {
+    return ethers.utils.defaultAbiCoder.encode([Commitment.TypeEncoding], [this.orderForEnc()])
   }
 }

--- a/src/enveloping/Commitment.ts
+++ b/src/enveloping/Commitment.ts
@@ -22,6 +22,7 @@ export class Commitment {
   relayHubAddress: Address
   relayWorker: Address
   enabledQos: BoolString
+  signature: PrefixedHexString
 
   constructor (
     time: Number,
@@ -30,7 +31,8 @@ export class Commitment {
     data: PrefixedHexString,
     relayHubAddress: Address,
     relayWorker: Address,
-    enabledQos: BoolString | undefined
+    enabledQos: BoolString | undefined,
+    signature: PrefixedHexString
   ) {
     this.time = time
     this.from = from
@@ -39,6 +41,7 @@ export class Commitment {
     this.relayHubAddress = relayHubAddress
     this.relayWorker = relayWorker
     this.enabledQos = enabledQos === 'true' ? 'true' : 'false'
+    this.signature = signature
   }
 
   public static TypeEncoding = 'commit(uint,address,address,bytes,address,address,bool)'

--- a/src/enveloping/Commitment.ts
+++ b/src/enveloping/Commitment.ts
@@ -21,7 +21,7 @@ export class Commitment {
   data: PrefixedHexString
   relayHubAddress: Address
   relayWorker: Address
-  enabledQos: BoolString
+  enableQos: BoolString
   signature: PrefixedHexString
 
   constructor (
@@ -31,7 +31,7 @@ export class Commitment {
     data: PrefixedHexString,
     relayHubAddress: Address,
     relayWorker: Address,
-    enabledQos: BoolString | undefined,
+    enableQos: BoolString | undefined,
     signature: PrefixedHexString
   ) {
     this.time = time
@@ -40,7 +40,7 @@ export class Commitment {
     this.data = data
     this.relayHubAddress = relayHubAddress
     this.relayWorker = relayWorker
-    this.enabledQos = enabledQos === 'true' ? 'true' : 'false'
+    this.enableQos = enableQos === 'true' ? 'true' : 'false'
     this.signature = signature
   }
 
@@ -54,7 +54,7 @@ export class Commitment {
       this.data,
       this.relayHubAddress,
       this.relayWorker,
-      this.enabledQos
+      this.enableQos
     ]
   }
 

--- a/src/enveloping/CommitmentValidator.ts
+++ b/src/enveloping/CommitmentValidator.ts
@@ -24,7 +24,7 @@ export class CommitmentValidator {
         receipt.commitment.signature
       )
       try {
-        const hash = ethers.utils.keccak256(commitment.encodeForSign(receipt.commitment.relayHubAddress))
+        const hash = ethers.utils.keccak256(commitment.encodeForSign())
         const recoveredAddress = ethers.utils.verifyMessage(ethers.utils.arrayify(hash), receipt.workerSignature)
         if (recoveredAddress.toLowerCase() === receipt.workerAddress.toLowerCase()) {
           return true

--- a/src/enveloping/CommitmentValidator.ts
+++ b/src/enveloping/CommitmentValidator.ts
@@ -20,7 +20,7 @@ export class CommitmentValidator {
         receipt.commitment.data,
         receipt.commitment.relayHubAddress,
         receipt.commitment.relayWorker,
-        receipt.commitment.enabledQos,
+        receipt.commitment.enableQos,
         receipt.commitment.signature
       )
       try {

--- a/src/enveloping/CommitmentValidator.ts
+++ b/src/enveloping/CommitmentValidator.ts
@@ -20,7 +20,8 @@ export class CommitmentValidator {
         receipt.commitment.data,
         receipt.commitment.relayHubAddress,
         receipt.commitment.relayWorker,
-        receipt.commitment.enabledQos
+        receipt.commitment.enabledQos,
+        receipt.commitment.signature
       )
       try {
         const hash = ethers.utils.keccak256(commitment.encodeForSign(receipt.commitment.relayHubAddress))

--- a/src/relayclient/Enveloping.ts
+++ b/src/relayclient/Enveloping.ts
@@ -64,7 +64,7 @@ export class Enveloping {
     * @param  recoverer optional: This SmartWallet instance won't have recovery support
     * @return a deploy request structure.
     */
-  async createDeployRequest (from: Address, tokenContract: Address, tokenAmount: IntString, tokenGas: IntString, gasPrice?: IntString, index? : IntString, recoverer? : IntString): Promise<DeployRequest> {
+  async createDeployRequest (from: Address, tokenContract: Address, tokenAmount: IntString, tokenGas: IntString, enableQos: boolean, gasPrice?: IntString, index? : IntString, recoverer? : IntString): Promise<DeployRequest> {
     const deployRequest: DeployRequest = {
       request: {
         relayHub: this.config.relayHubAddress,
@@ -76,7 +76,7 @@ export class Enveloping {
         tokenContract: tokenContract,
         tokenAmount: tokenAmount,
         tokenGas: tokenGas,
-        enableQos: false,
+        enableQos: enableQos,
         recoverer: recoverer ?? constants.ZERO_ADDRESS,
         index: index ?? '0'
       },
@@ -126,7 +126,7 @@ export class Enveloping {
     * @param  gasPrice - optional: if not set, the gasPrice is calculated internally
     * @return a relay request structure.
     */
-  async createRelayRequest (from: Address, to: Address, forwarder: Address, data: PrefixedHexString, tokenContract: Address, tokenAmount: IntString, tokenGas: IntString, gasLimit?: IntString, gasPrice?: IntString): Promise<RelayRequest> {
+  async createRelayRequest (from: Address, to: Address, forwarder: Address, data: PrefixedHexString, tokenContract: Address, tokenAmount: IntString, tokenGas: IntString, enableQos: boolean, gasLimit?: IntString, gasPrice?: IntString): Promise<RelayRequest> {
     let gasToSend = gasLimit
     const gasPriceToSend = gasPrice ?? await web3.eth.getGasPrice()
 
@@ -147,7 +147,7 @@ export class Enveloping {
         tokenContract: tokenContract,
         tokenAmount: tokenAmount,
         tokenGas: tokenGas,
-        enableQos: false
+        enableQos: enableQos
       },
       relayData: {
         gasPrice: gasPriceToSend,

--- a/src/relayclient/Enveloping.ts
+++ b/src/relayclient/Enveloping.ts
@@ -76,7 +76,7 @@ export class Enveloping {
         tokenContract: tokenContract,
         tokenAmount: tokenAmount,
         tokenGas: tokenGas,
-        enableQos: 'false',
+        enableQos: false,
         recoverer: recoverer ?? constants.ZERO_ADDRESS,
         index: index ?? '0'
       },
@@ -147,7 +147,7 @@ export class Enveloping {
         tokenContract: tokenContract,
         tokenAmount: tokenAmount,
         tokenGas: tokenGas,
-        enableQos: 'false',
+        enableQos: false
       },
       relayData: {
         gasPrice: gasPriceToSend,

--- a/src/relayclient/Enveloping.ts
+++ b/src/relayclient/Enveloping.ts
@@ -76,6 +76,7 @@ export class Enveloping {
         tokenContract: tokenContract,
         tokenAmount: tokenAmount,
         tokenGas: tokenGas,
+        enableQos: 'false',
         recoverer: recoverer ?? constants.ZERO_ADDRESS,
         index: index ?? '0'
       },
@@ -145,7 +146,8 @@ export class Enveloping {
         nonce: (await this.getSenderNonce(forwarder)).toString(),
         tokenContract: tokenContract,
         tokenAmount: tokenAmount,
-        tokenGas: tokenGas
+        tokenGas: tokenGas,
+        enableQos: 'false',
       },
       relayData: {
         gasPrice: gasPriceToSend,

--- a/src/relayclient/HttpClient.ts
+++ b/src/relayclient/HttpClient.ts
@@ -41,8 +41,6 @@ export default class HttpClient {
     if (signedReceipt == null) {
       throw new Error('body.signedReceipt field missing.')
     }
-    log.info('commitment response 1')
-    log.info({ signedTx, signedReceipt, transactionHash })
     return { signedTx, signedReceipt, transactionHash }
   }
 }

--- a/src/relayclient/HttpClient.ts
+++ b/src/relayclient/HttpClient.ts
@@ -41,6 +41,8 @@ export default class HttpClient {
     if (signedReceipt == null) {
       throw new Error('body.signedReceipt field missing.')
     }
+    log.info('commitment response 1')
+    log.info({ signedTx, signedReceipt, transactionHash })
     return { signedTx, signedReceipt, transactionHash }
   }
 }

--- a/src/relayclient/RelayClient.ts
+++ b/src/relayclient/RelayClient.ts
@@ -300,7 +300,7 @@ export class RelayClient {
         nonce: senderNonce,
         tokenAmount: tokenAmount,
         tokenGas: tokenGas,
-        enableQos: 'false',
+        enableQos: false,
         tokenContract: transactionDetails.tokenContract ?? constants.ZERO_ADDRESS,
         recoverer: transactionDetails.recoverer ?? constants.ZERO_ADDRESS,
         index: transactionDetails.index ?? '0'
@@ -544,7 +544,7 @@ export class RelayClient {
         nonce: senderNonce,
         tokenAmount: transactionDetails.tokenAmount ?? '0x00',
         tokenGas: transactionDetails.tokenGas ?? '0x00',
-        enableQos: 'false',
+        enableQos: false,
         tokenContract: transactionDetails.tokenContract ?? constants.ZERO_ADDRESS,
         recoverer: transactionDetails.recoverer ?? constants.ZERO_ADDRESS,
         index: transactionDetails.index ?? '0'
@@ -616,7 +616,7 @@ export class RelayClient {
         gas: gasLimit,
         tokenAmount: transactionDetails.tokenAmount ?? '0x00',
         tokenGas: transactionDetails.tokenGas ?? '0x00',
-        enableQos: 'false',
+        enableQos: false,
         tokenContract: transactionDetails.tokenContract ?? constants.ZERO_ADDRESS
       },
       relayData: {

--- a/src/relayclient/RelayClient.ts
+++ b/src/relayclient/RelayClient.ts
@@ -300,6 +300,7 @@ export class RelayClient {
         nonce: senderNonce,
         tokenAmount: tokenAmount,
         tokenGas: tokenGas,
+        enableQos: 'false',
         tokenContract: transactionDetails.tokenContract ?? constants.ZERO_ADDRESS,
         recoverer: transactionDetails.recoverer ?? constants.ZERO_ADDRESS,
         index: transactionDetails.index ?? '0'
@@ -543,6 +544,7 @@ export class RelayClient {
         nonce: senderNonce,
         tokenAmount: transactionDetails.tokenAmount ?? '0x00',
         tokenGas: transactionDetails.tokenGas ?? '0x00',
+        enableQos: 'false',
         tokenContract: transactionDetails.tokenContract ?? constants.ZERO_ADDRESS,
         recoverer: transactionDetails.recoverer ?? constants.ZERO_ADDRESS,
         index: transactionDetails.index ?? '0'

--- a/src/relayclient/RelayClient.ts
+++ b/src/relayclient/RelayClient.ts
@@ -300,7 +300,7 @@ export class RelayClient {
         nonce: senderNonce,
         tokenAmount: tokenAmount,
         tokenGas: tokenGas,
-        enableQos: false,
+        enableQos: transactionDetails.enableQos ?? false,
         tokenContract: transactionDetails.tokenContract ?? constants.ZERO_ADDRESS,
         recoverer: transactionDetails.recoverer ?? constants.ZERO_ADDRESS,
         index: transactionDetails.index ?? '0'
@@ -544,7 +544,7 @@ export class RelayClient {
         nonce: senderNonce,
         tokenAmount: transactionDetails.tokenAmount ?? '0x00',
         tokenGas: transactionDetails.tokenGas ?? '0x00',
-        enableQos: false,
+        enableQos: transactionDetails.enableQos ?? false,
         tokenContract: transactionDetails.tokenContract ?? constants.ZERO_ADDRESS,
         recoverer: transactionDetails.recoverer ?? constants.ZERO_ADDRESS,
         index: transactionDetails.index ?? '0'
@@ -616,7 +616,7 @@ export class RelayClient {
         gas: gasLimit,
         tokenAmount: transactionDetails.tokenAmount ?? '0x00',
         tokenGas: transactionDetails.tokenGas ?? '0x00',
-        enableQos: false,
+        enableQos: transactionDetails.enableQos ?? false,
         tokenContract: transactionDetails.tokenContract ?? constants.ZERO_ADDRESS
       },
       relayData: {

--- a/src/relayclient/RelayClient.ts
+++ b/src/relayclient/RelayClient.ts
@@ -616,6 +616,7 @@ export class RelayClient {
         gas: gasLimit,
         tokenAmount: transactionDetails.tokenAmount ?? '0x00',
         tokenGas: transactionDetails.tokenGas ?? '0x00',
+        enableQos: 'false',
         tokenContract: transactionDetails.tokenContract ?? constants.ZERO_ADDRESS
       },
       relayData: {

--- a/src/relayclient/types/EnvelopingTransactionDetails.ts
+++ b/src/relayclient/types/EnvelopingTransactionDetails.ts
@@ -52,4 +52,6 @@ export default interface EnvelopingTransactionDetails {
 
   retries?: number
   initialBackoff?: number
+
+  enableQos?: boolean
 }

--- a/src/relayclient/types/RelayTransactionRequest.ts
+++ b/src/relayclient/types/RelayTransactionRequest.ts
@@ -32,7 +32,7 @@ export const DeployTransactionRequestShape = {
       tokenContract: ow.string,
       tokenAmount: ow.string,
       tokenGas: ow.string,
-      enableQos: ow.string,
+      enableQos: ow.boolean,
       recoverer: ow.string,
       index: ow.string
     },
@@ -65,7 +65,7 @@ export const RelayTransactionRequestShape = {
       tokenContract: ow.string,
       tokenAmount: ow.string,
       tokenGas: ow.string,
-      enableQos: ow.string
+      enableQos: ow.boolean
     },
     relayData: {
       gasPrice: ow.string,

--- a/src/relayclient/types/RelayTransactionRequest.ts
+++ b/src/relayclient/types/RelayTransactionRequest.ts
@@ -32,6 +32,7 @@ export const DeployTransactionRequestShape = {
       tokenContract: ow.string,
       tokenAmount: ow.string,
       tokenGas: ow.string,
+      enableQos: ow.string,
       recoverer: ow.string,
       index: ow.string
     },
@@ -63,7 +64,8 @@ export const RelayTransactionRequestShape = {
       data: ow.string,
       tokenContract: ow.string,
       tokenAmount: ow.string,
-      tokenGas: ow.string
+      tokenGas: ow.string,
+      enableQos: ow.string
     },
     relayData: {
       gasPrice: ow.string,

--- a/src/relayserver/HttpServer.ts
+++ b/src/relayserver/HttpServer.ts
@@ -134,21 +134,7 @@ export class HttpServer {
       log.error(`verified handler rejected: ${message}`)
     }
   }
-
-  // temp
-  async penalizerHandler (req: Request, res: Response): Promise<void> {
-    try {
-      const penalizerAddress = req.query.penalizer as Address
-      const signature = req.query.signature as PrefixedHexString
-      const penalizerResponse = await this.backend.penalizerHandler(penalizerAddress, signature)
-      res.send(penalizerResponse)
-    } catch (e) {
-      const message: string = e.message
-      res.send({ message })
-      log.error(`penalizer handler rejected: ${message}`)
-    }
-  }
-
+  
   async feeEstimatorHandler (req: any, res: any): Promise<void> {
     const feesTable = await this.backend.envelopingArbiter.getFeesTable()
     res.send(feesTable)

--- a/src/relayserver/HttpServer.ts
+++ b/src/relayserver/HttpServer.ts
@@ -140,7 +140,7 @@ export class HttpServer {
     try {
       const penalizerAddress = req.query.penalizer as Address
       const signature = req.query.signature as PrefixedHexString
-      const penalizerResponse = await this.backend.penalizerHandler(penalizerAddress)
+      const penalizerResponse = await this.backend.penalizerHandler(penalizerAddress, signature)
       res.send(penalizerResponse)
     } catch (e) {
       const message: string = e.message

--- a/src/relayserver/HttpServer.ts
+++ b/src/relayserver/HttpServer.ts
@@ -6,7 +6,6 @@ import { RelayServer } from './RelayServer'
 import { Server } from 'http'
 import log from 'loglevel'
 import { Address } from '../relayclient/types/Aliases'
-import { PrefixedHexString } from 'ethereumjs-tx'
 
 export class HttpServer {
   app: Express

--- a/src/relayserver/HttpServer.ts
+++ b/src/relayserver/HttpServer.ts
@@ -133,7 +133,7 @@ export class HttpServer {
       log.error(`verified handler rejected: ${message}`)
     }
   }
-  
+
   async feeEstimatorHandler (req: any, res: any): Promise<void> {
     const feesTable = await this.backend.envelopingArbiter.getFeesTable()
     res.send(feesTable)

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -386,8 +386,6 @@ export class RelayServer extends EventEmitter {
     const { signedTx, transactionHash } = await this.transactionManager.sendTransaction(details)
     // after sending a transaction is a good time to check the worker's balance, and replenish it.
     await this.replenishServer(workerIndex, currentBlock)
-    log.info('commitment response 2')
-    log.info({ signedTx: signedTx, signedReceipt: commitmentReceipt, transactionHash: transactionHash })
     return { signedTx: signedTx, signedReceipt: commitmentReceipt, transactionHash: transactionHash }
   }
 

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -376,7 +376,8 @@ export class RelayServer extends EventEmitter {
       req.relayRequest.request.data,
       req.metadata.relayHubAddress,
       req.relayRequest.relayData.relayWorker,
-      req.relayRequest.request.enabledQos
+      req.relayRequest.request.enabledQos,
+      req.metadata.signature
     )
     const digest = ethers.utils.keccak256(commitment.encodeForSign(this.relayHubContract.address))
     const signature = await this.envelopingArbiter.signCommitment(this.transactionManager, commitment.relayWorker, ethers.utils.arrayify(digest))

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -380,7 +380,7 @@ export class RelayServer extends EventEmitter {
       req.relayRequest.request.enableQos,
       req.metadata.signature
     )
-    const digest = ethers.utils.keccak256(commitment.encodeForSign(this.relayHubContract.address))
+    const digest = ethers.utils.keccak256(commitment.encodeForSign())
     const signature = await this.envelopingArbiter.signCommitment(this.transactionManager, commitment.relayWorker, ethers.utils.arrayify(digest))
     const commitmentReceipt = {
       commitment: commitment,

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -394,6 +394,8 @@ export class RelayServer extends EventEmitter {
     const { signedTx, transactionHash } = await this.transactionManager.sendTransaction(details)
     // after sending a transaction is a good time to check the worker's balance, and replenish it.
     await this.replenishServer(workerIndex, currentBlock)
+    log.info('commitment response 2')
+    log.info({ signedTx: signedTx, signedReceipt: commitmentReceipt, transactionHash: transactionHash })
     return { signedTx: signedTx, signedReceipt: commitmentReceipt, transactionHash: transactionHash }
   }
 

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -160,14 +160,6 @@ export class RelayServer extends EventEmitter {
     return res
   }
 
-  // temp
-  async penalizerHandler (penalizer: Address, signature: PrefixedHexString): Promise<any> {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const penalizerInstance = await this.contractInteractor.createPenalizer(penalizer)
-    const transactionFulfilled = await penalizerInstance.fulfilled(signature)
-    return { transactionFulfilled: transactionFulfilled }
-  }
-
   async verifierHandler (): Promise<VerifierResponse> {
     return {
       trustedVerifiers: Array.from(this.trustedVerifiers) as Address[]

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -164,7 +164,8 @@ export class RelayServer extends EventEmitter {
   async penalizerHandler (penalizer: Address, signature: PrefixedHexString): Promise<any> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const penalizerInstance = await this.contractInteractor.createPenalizer(penalizer)
-    const transactionFulfilled = await penalizerInstance
+    const transactionFulfilled = await penalizerInstance.fulfilled(signature)
+    return { transactionFulfilled: transactionFulfilled }
   }
 
   async verifierHandler (): Promise<VerifierResponse> {

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -377,7 +377,7 @@ export class RelayServer extends EventEmitter {
       req.relayRequest.request.data,
       req.metadata.relayHubAddress,
       req.relayRequest.relayData.relayWorker,
-      req.relayRequest.request.enabledQos,
+      req.relayRequest.request.enableQos,
       req.metadata.signature
     )
     const digest = ethers.utils.keccak256(commitment.encodeForSign(this.relayHubContract.address))

--- a/test/EnvelopingUtils.test.ts
+++ b/test/EnvelopingUtils.test.ts
@@ -78,7 +78,7 @@ contract('Enveloping utils', function (accounts) {
     }
 
     const deploySmartWallet = async function deploySmartWallet (tokenContract: Address, tokenAmount: IntString, tokenGas: IntString): Promise<string|undefined> {
-      const deployRequest = await enveloping.createDeployRequest(gaslessAccount.address, tokenContract, tokenAmount, tokenGas, '1000000000', index)
+      const deployRequest = await enveloping.createDeployRequest(gaslessAccount.address, tokenContract, tokenAmount, tokenGas, false, '1000000000', index)
       const deploySignature = enveloping.signDeployRequest(signatureProvider, deployRequest)
       const httpDeployRequest = await enveloping.generateDeployTransactionRequest(deploySignature, deployRequest)
       const sentDeployTransaction = await enveloping.sendTransaction(localhost, httpDeployRequest)
@@ -92,9 +92,9 @@ contract('Enveloping utils', function (accounts) {
       assert.equal(deployedCode, expectedCode)
     }
 
-    const relayTransaction = async function relayTransaction (tokenContract: Address, tokenAmount: IntString, tokenGas: IntString): Promise<string|undefined> {
+    const relayTransaction = async function relayTransaction (tokenContract: Address, tokenAmount: IntString, tokenGas: IntString, enableQos: boolean): Promise<string|undefined> {
       const encodedFunction = testRecipient.contract.methods.emitMessage(message).encodeABI()
-      const relayRequest = await enveloping.createRelayRequest(gaslessAccount.address, testRecipient.address, swAddress, encodedFunction, tokenContract, tokenAmount, tokenGas)
+      const relayRequest = await enveloping.createRelayRequest(gaslessAccount.address, testRecipient.address, swAddress, encodedFunction, tokenContract, tokenAmount, tokenGas, enableQos)
       const relaySignature = enveloping.signRelayRequest(signatureProvider, relayRequest)
       const httpRelayRequest = await enveloping.generateRelayTransactionRequest(relaySignature, relayRequest)
       const sentRelayTransaction = await enveloping.sendTransaction(localhost, httpRelayRequest)
@@ -178,7 +178,7 @@ contract('Enveloping utils', function (accounts) {
 
       await assertSmartWalletDeployedCorrectly(swAddress)
 
-      const txRelayHash = await relayTransaction(constants.ZERO_ADDRESS, '0', '0')
+      const txRelayHash = await relayTransaction(constants.ZERO_ADDRESS, '0', '0', false)
 
       if (txRelayHash === undefined) {
         assert.fail('Transacion has not been send or it threw an error')
@@ -218,7 +218,7 @@ contract('Enveloping utils', function (accounts) {
       const newBalance = await tokenContract.balanceOf(workerAddress)
       assert.equal(newBalance.toNumber(), previousBalance.add(balanceTransfered).toNumber())
 
-      const txRelayHash = await relayTransaction(tokenContract.address, '10', '50000')
+      const txRelayHash = await relayTransaction(tokenContract.address, '10', '50000', false)
 
       if (txRelayHash === undefined) {
         assert.fail('Transacion has not been send')

--- a/test/EnvelopingUtils.test.ts
+++ b/test/EnvelopingUtils.test.ts
@@ -9,6 +9,7 @@ import { SmartWalletFactoryInstance, RelayHubInstance, SmartWalletInstance, Test
 import {
   createSmartWalletFactory,
   deployHub,
+  getHostnameFromProvider,
   getTestingEnvironment,
   hasCode,
   startRelay,
@@ -256,7 +257,8 @@ contract('Enveloping utils', function (accounts) {
 
     before(async function () {
       chainId = (await getTestingEnvironment()).chainId
-      socketProvider = new Web3.providers.WebsocketProvider('ws://127.0.0.1:4445/websocket')
+
+      socketProvider = new Web3.providers.WebsocketProvider(`ws://${getHostnameFromProvider()}:4445/websocket`)
 
       currentWeb3 = new Web3(socketProvider)
 
@@ -361,7 +363,7 @@ contract('Enveloping utils', function (accounts) {
 
     before(async function () {
       chainId = (await getTestingEnvironment()).chainId
-      socketProvider = new Web3.providers.WebsocketProvider('ws://127.0.0.1:4445/websocket')
+      socketProvider = new Web3.providers.WebsocketProvider(`ws://${getHostnameFromProvider()}:4445/websocket`)
 
       currentWeb3 = new Web3(socketProvider)
 
@@ -467,7 +469,7 @@ contract('Enveloping utils', function (accounts) {
 
     before(async function () {
       chainId = (await getTestingEnvironment()).chainId
-      socketProvider = new Web3.providers.WebsocketProvider('ws://127.0.0.1:4445/websocket')
+      socketProvider = new Web3.providers.WebsocketProvider(`ws://${getHostnameFromProvider()}:4445/websocket`)
 
       currentWeb3 = new Web3(socketProvider)
 

--- a/test/Flows.test.ts
+++ b/test/Flows.test.ts
@@ -14,7 +14,7 @@ import {
   SmartWalletFactoryInstance,
   TestDeployVerifierEverythingAcceptedInstance
 } from '../types/truffle-contracts'
-import { deployHub, startRelay, stopRelay, getTestingEnvironment, createSmartWalletFactory, createSmartWallet, getExistingGaslessAccount } from './TestUtils'
+import { startRelay, stopRelay, getTestingEnvironment, createSmartWalletFactory, createSmartWallet, getExistingGaslessAccount, deployHubAndPenalizer } from './TestUtils'
 import { ChildProcessWithoutNullStreams } from 'child_process'
 import { EnvelopingConfig } from '../src/relayclient/Configurator'
 import { toBuffer } from 'ethereumjs-util'
@@ -24,7 +24,6 @@ const TestRecipient = artifacts.require('tests/TestRecipient')
 const TestVerifierEverythingAccepted = artifacts.require('tests/TestVerifierEverythingAccepted')
 const TestDeployVerifierEverythingAccepted = artifacts.require('tests/TestDeployVerifierEverythingAccepted')
 
-const Penalizer = artifacts.require('Penalizer')
 const SmartWallet = artifacts.require('SmartWallet')
 
 const options = [
@@ -60,11 +59,11 @@ options.forEach(params => {
       // An account from RSK that has been depleted to ensure it has no funds
       gaslessAccount = await getExistingGaslessAccount()
 
-      const p = await Penalizer.new()
       verifier = await TestVerifierEverythingAccepted.new()
-      deployVerifier = await TestDeployVerifierEverythingAccepted.new()
+      deployVerifier = await TestDeployVerifierEverythingAccepted.new();
 
-      rhub = await deployHub(p.address)
+      ({ relayHub: rhub } = await deployHubAndPenalizer())
+
       if (params.relay) {
         process.env.relaylog = 'true'
         relayproc = (await startRelay(rhub, {

--- a/test/GasAttacks.test.ts
+++ b/test/GasAttacks.test.ts
@@ -92,7 +92,7 @@ contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker]) {
           tokenContract: token.address,
           tokenAmount: '1',
           tokenGas: '50000',
-          enableQos: 'false'
+          enableQos: false
         },
         relayData: {
           gasPrice,

--- a/test/GasAttacks.test.ts
+++ b/test/GasAttacks.test.ts
@@ -91,7 +91,8 @@ contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker]) {
           gas: gasLimit,
           tokenContract: token.address,
           tokenAmount: '1',
-          tokenGas: '50000'
+          tokenGas: '50000',
+          enableQos: 'false'
         },
         relayData: {
           gasPrice,

--- a/test/GasAttacks.test.ts
+++ b/test/GasAttacks.test.ts
@@ -13,7 +13,6 @@ import abiDecoder from 'abi-decoder'
 
 import {
   RelayHubInstance,
-  PenalizerInstance,
   TestRecipientInstance,
   IForwarderInstance,
   TestVerifierEverythingAcceptedInstance,
@@ -21,7 +20,7 @@ import {
   SmartWalletFactoryInstance,
   TestTokenInstance
 } from '../types/truffle-contracts'
-import { deployHub, getTestingEnvironment, createSmartWallet, getGaslessAccount, createSmartWalletFactory } from './TestUtils'
+import { getTestingEnvironment, createSmartWallet, getGaslessAccount, createSmartWalletFactory, deployHubAndPenalizer } from './TestUtils'
 
 import chaiAsPromised from 'chai-as-promised'
 import { AccountKeypair } from '../src/relayclient/AccountManager'
@@ -29,7 +28,6 @@ import { toBN } from 'web3-utils'
 
 const { assert } = chai.use(chaiAsPromised)
 const SmartWallet = artifacts.require('SmartWallet')
-const Penalizer = artifacts.require('Penalizer')
 const TestVerifierEverythingAccepted = artifacts.require('TestVerifierEverythingAccepted')
 const TestRecipient = artifacts.require('TestRecipient')
 
@@ -41,7 +39,6 @@ abiDecoder.addABI(relayHubAbi)
 contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker]) {
   let chainId: number
   let relayHub: string
-  let penalizer: PenalizerInstance
   let relayHubInstance: RelayHubInstance
   let recipientContract: TestRecipientInstance
   let verifierContract: TestVerifierEverythingAcceptedInstance
@@ -60,10 +57,9 @@ contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker]) {
   describe('relayCall', function () {
     beforeEach(async function () {
       env = await getTestingEnvironment()
-      chainId = env.chainId
+      chainId = env.chainId;
 
-      penalizer = await Penalizer.new()
-      relayHubInstance = await deployHub(penalizer.address)
+      ({ relayHub: relayHubInstance } = await deployHubAndPenalizer())
       verifierContract = await TestVerifierEverythingAccepted.new()
       gaslessAccount = await getGaslessAccount()
 

--- a/test/RelayHub.test.ts
+++ b/test/RelayHub.test.ts
@@ -101,7 +101,8 @@ contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker, incorr
           gas: gasLimit,
           tokenContract: token.address,
           tokenAmount: '1',
-          tokenGas: '50000'
+          tokenGas: '50000',
+          enableQos: 'false'
         },
         relayData: {
           gasPrice,
@@ -284,7 +285,8 @@ contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker, incorr
           gas: gasLimit,
           tokenContract: token.address,
           tokenAmount: '1',
-          tokenGas: '50000'
+          tokenGas: '50000',
+          enableQos: 'false'
         },
         relayData: {
           gasPrice,
@@ -1281,6 +1283,7 @@ contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker, incorr
           tokenContract: token.address,
           tokenAmount: '1',
           tokenGas: '50000',
+          enableQos: 'false',
           recoverer: constants.ZERO_ADDRESS,
           index: '0'
         },

--- a/test/RelayHub.test.ts
+++ b/test/RelayHub.test.ts
@@ -102,7 +102,7 @@ contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker, incorr
           tokenContract: token.address,
           tokenAmount: '1',
           tokenGas: '50000',
-          enableQos: 'false'
+          enableQos: false
         },
         relayData: {
           gasPrice,
@@ -286,7 +286,7 @@ contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker, incorr
           tokenContract: token.address,
           tokenAmount: '1',
           tokenGas: '50000',
-          enableQos: 'false'
+          enableQos: false
         },
         relayData: {
           gasPrice,
@@ -1283,7 +1283,7 @@ contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker, incorr
           tokenContract: token.address,
           tokenAmount: '1',
           tokenGas: '50000',
-          enableQos: 'false',
+          enableQos: false,
           recoverer: constants.ZERO_ADDRESS,
           index: '0'
         },

--- a/test/RelayHubPenalizations.test.ts
+++ b/test/RelayHubPenalizations.test.ts
@@ -51,7 +51,7 @@ contract('RelayHub Penalizations', function ([defaultAccount, relayOwner, relayW
       tokenContract: constants.ZERO_ADDRESS,
       tokenAmount: '0',
       tokenGas: '0',
-      enableQos: 'false'
+      enableQos: false
     },
     relayData: {
       gasPrice: '50',

--- a/test/RelayHubPenalizations.test.ts
+++ b/test/RelayHubPenalizations.test.ts
@@ -134,7 +134,7 @@ contract('RelayHub Penalizations', function ([defaultAccount, relayOwner, relayW
     describe('penalization access control (relay hub only)', function () {
       it('revert with unknown relay hub message', async () => {
         await expectRevert(
-          penalizer.fulfill(RANDOM_TX_SIGNATURE, relayHub.address),
+          penalizer.fulfill(RANDOM_TX_SIGNATURE),
           'Unknown relay hub'
         )
       })

--- a/test/RelayHubPenalizations.test.ts
+++ b/test/RelayHubPenalizations.test.ts
@@ -30,6 +30,8 @@ const Penalizer = artifacts.require('Penalizer')
 const TestVerifierEverythingAccepted = artifacts.require('TestVerifierEverythingAccepted')
 const SmartWallet = artifacts.require('SmartWallet')
 
+const RANDOM_TX_SIGNATURE = '0x74be69218f14e914f53573644b4b0efe304f5e5d7e215642a9b6f34de09486f9601f0f34320acbd448bd051831df36b43d54be30b01e61930875ab2b6d4ada391b'
+
 contract('RelayHub Penalizations', function ([defaultAccount, relayOwner, relayWorker, otherRelayWorker, sender, other, relayManager, otherRelayManager, thirdRelayWorker, reporterRelayManager]) { // eslint-disable-line no-unused-vars
   let relayHub: RelayHubInstance
   let penalizer: PenalizerInstance
@@ -125,6 +127,15 @@ contract('RelayHub Penalizations', function ([defaultAccount, relayOwner, relayW
         await expectRevert(
           penalizer.penalizeRepeatedNonce(penalizableTxData, penalizableTxSignature, penalizableTxData, penalizableTxSignature, relayHub.address, { from: other }),
           'Unknown relay manager'
+        )
+      })
+    })
+
+    describe('penalization access control (relay hub only)', function () {
+      it('revert with unknown relay hub message', async () => {
+        await expectRevert(
+          penalizer.fulfill(RANDOM_TX_SIGNATURE, relayHub.address),
+          'Unknown relay hub'
         )
       })
     })

--- a/test/RelayHubPenalizations.test.ts
+++ b/test/RelayHubPenalizations.test.ts
@@ -135,7 +135,7 @@ contract('RelayHub Penalizations', function ([defaultAccount, relayOwner, relayW
     describe('penalization access control (relay hub only)', function () {
       it('revert with unknown relay hub message', async () => {
         await expectRevert(
-          penalizer.fulfill(RANDOM_TX_SIGNATURE),
+          penalizer.fulfill(web3.utils.keccak256(RANDOM_TX_SIGNATURE)),
           'Unknown Relay Hub'
         )
       })

--- a/test/RelayHubPenalizations.test.ts
+++ b/test/RelayHubPenalizations.test.ts
@@ -50,7 +50,8 @@ contract('RelayHub Penalizations', function ([defaultAccount, relayOwner, relayW
       gas: '1000000',
       tokenContract: constants.ZERO_ADDRESS,
       tokenAmount: '0',
-      tokenGas: '0'
+      tokenGas: '0',
+      enableQos: 'false'
     },
     relayData: {
       gasPrice: '50',

--- a/test/RelayHubPenalizations.test.ts
+++ b/test/RelayHubPenalizations.test.ts
@@ -136,7 +136,7 @@ contract('RelayHub Penalizations', function ([defaultAccount, relayOwner, relayW
       it('revert with unknown relay hub message', async () => {
         await expectRevert(
           penalizer.fulfill(RANDOM_TX_SIGNATURE),
-          'Unknown relay hub'
+          'Unknown Relay Hub'
         )
       })
     })

--- a/test/RelayHubRegistrationsManagement.test.ts
+++ b/test/RelayHubRegistrationsManagement.test.ts
@@ -2,18 +2,14 @@ import { ether, expectEvent, expectRevert } from '@openzeppelin/test-helpers'
 import { RelayHubConfiguration } from '../src/relayclient/types/RelayHubConfiguration'
 
 import {
-  PenalizerInstance,
   RelayHubInstance
 } from '../types/truffle-contracts'
-import { deployHub } from './TestUtils'
-
-const Penalizer = artifacts.require('Penalizer')
+import { deployHubAndPenalizer } from './TestUtils'
 
 contract('RelayHub Relay Management', function ([_, relayOwner, relayManager, relayWorker1, relayWorker2, relayWorker3]) {
   const relayUrl = 'http://new-relay.com'
 
   let relayHub: RelayHubInstance
-  let penalizer: PenalizerInstance
 
   const maxWorkerCount = 3
   const minimumEntryDepositValue = ether('1').toString()
@@ -28,8 +24,7 @@ contract('RelayHub Relay Management', function ([_, relayOwner, relayManager, re
   }
 
   beforeEach(async function () {
-    penalizer = await Penalizer.new()
-    relayHub = await deployHub(penalizer.address, hubConfig)
+    ({ relayHub } = await deployHubAndPenalizer(hubConfig))
   })
 
   context('without stake for relayManager', function () {

--- a/test/StakeManagement.test.ts
+++ b/test/StakeManagement.test.ts
@@ -54,11 +54,14 @@ contract('StakeManagement', function ([_, relayManager, worker, anyRelayHub, own
     })
   }
 
+  beforeEach(async function () {
+    relayHub = await RelayHub.new(maxWorkerCount, minimumEntryDepositValue, minimumUnstakeDelay, minimumStake)
+  })
+
   describe('with no stake for relay server', function () {
     beforeEach(async function () {
-      penalizer = await Penalizer.new()
-      relayHub = await RelayHub.new(penalizer.address, maxWorkerCount,
-        minimumEntryDepositValue, minimumUnstakeDelay, minimumStake)
+      penalizer = await Penalizer.new(relayHub.address)
+      await relayHub.setPenalizer(penalizer.address)
     })
 
     testStakeNotValid()
@@ -85,9 +88,6 @@ contract('StakeManagement', function ([_, relayManager, worker, anyRelayHub, own
 
   describe('with stake deposited for relay server', function () {
     beforeEach(async function () {
-      relayHub = await RelayHub.new(constants.ZERO_ADDRESS, maxWorkerCount,
-        minimumEntryDepositValue, minimumUnstakeDelay, minimumStake)
-
       await relayHub.stakeForAddress(relayManager, initialUnstakeDelay, {
         value: initialStake,
         from: owner
@@ -180,9 +180,6 @@ contract('StakeManagement', function ([_, relayManager, worker, anyRelayHub, own
 
   describe('with authorized hub', function () {
     beforeEach(async function () {
-      relayHub = await RelayHub.new(constants.ZERO_ADDRESS, maxWorkerCount,
-        minimumEntryDepositValue, minimumUnstakeDelay, minimumStake)
-
       await relayHub.stakeForAddress(relayManager, initialUnstakeDelay, {
         value: initialStake,
         from: owner
@@ -214,9 +211,6 @@ contract('StakeManagement', function ([_, relayManager, worker, anyRelayHub, own
 
   describe('with unlock scheduled', function () {
     beforeEach(async function () {
-      relayHub = await RelayHub.new(constants.ZERO_ADDRESS, maxWorkerCount,
-        minimumEntryDepositValue, minimumUnstakeDelay, minimumStake)
-
       await relayHub.stakeForAddress(relayManager, initialUnstakeDelay, {
         value: initialStake,
         from: owner

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -27,6 +27,7 @@ import { AccountKeypair } from '../src/relayclient/AccountManager'
 import ethWallet from 'ethereumjs-wallet'
 import { Address } from '../src/relayclient/types/Aliases'
 import { DeployRequest, RelayRequest } from '../src/common/EIP712/RelayRequest'
+import { HttpProvider } from 'web3-core'
 
 require('source-map-support').install({ errorFormatterForce: true })
 
@@ -537,3 +538,10 @@ export function hasCode (code: string): boolean {
  * Not all "signatures" are valid, so using a hard-coded one for predictable error message.
  */
 export const INCORRECT_ECDSA_SIGNATURE = '0xdeadface00000a58b757da7dea5678548be5ff9b16e9d1d87c6157aff6889c0f6a406289908add9ea6c3ef06d033a058de67d057e2c0ae5a02b36854be13b0731c'
+
+export const getHostnameFromProvider = (): string => {
+  const underlyingProvider = web3.currentProvider as HttpProvider
+  const providerUrl = new URL(underlyingProvider.host)
+  const hostname = providerUrl.hostname
+  return hostname
+}

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -313,6 +313,7 @@ export async function createSmartWallet (relayHub: string, ownerEOA: string, fac
       tokenContract: tokenContract,
       tokenAmount: tokenAmount,
       tokenGas: tokenGas,
+      enableQos: 'false',
       recoverer: recoverer,
       index: '0'
     },
@@ -366,6 +367,7 @@ export async function createCustomSmartWallet (relayHub: string, ownerEOA: strin
       tokenContract: tokenContract,
       tokenAmount: tokenAmount,
       tokenGas: tokenGas,
+      enableQos: 'false',
       recoverer: recoverer,
       index: '0'
     },
@@ -464,7 +466,8 @@ export async function prepareTransaction (relayHub: Address, testRecipient: Test
       gas: '200000',
       tokenContract: tokenContract,
       tokenAmount: tokenAmount,
-      tokenGas: tokenGas
+      tokenGas: tokenGas,
+      enableQos: 'false',
     },
     relayData: {
       gasPrice: '1',

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -313,7 +313,7 @@ export async function createSmartWallet (relayHub: string, ownerEOA: string, fac
       tokenContract: tokenContract,
       tokenAmount: tokenAmount,
       tokenGas: tokenGas,
-      enableQos: 'false',
+      enableQos: false,
       recoverer: recoverer,
       index: '0'
     },
@@ -367,7 +367,7 @@ export async function createCustomSmartWallet (relayHub: string, ownerEOA: strin
       tokenContract: tokenContract,
       tokenAmount: tokenAmount,
       tokenGas: tokenGas,
-      enableQos: 'false',
+      enableQos: false,
       recoverer: recoverer,
       index: '0'
     },
@@ -467,7 +467,7 @@ export async function prepareTransaction (relayHub: Address, testRecipient: Test
       tokenContract: tokenContract,
       tokenAmount: tokenAmount,
       tokenGas: tokenGas,
-      enableQos: 'false',
+      enableQos: false
     },
     relayData: {
       gasPrice: '1',

--- a/test/Utils.test.ts
+++ b/test/Utils.test.ts
@@ -65,7 +65,8 @@ contract('Utils', function (accounts) {
           gas: gasLimit,
           tokenContract: constants.ZERO_ADDRESS,
           tokenAmount: '0',
-          tokenGas: '0'
+          tokenGas: '0',
+          enableQos: 'false'
         },
         relayData: {
           gasPrice,

--- a/test/Utils.test.ts
+++ b/test/Utils.test.ts
@@ -66,7 +66,7 @@ contract('Utils', function (accounts) {
           tokenContract: constants.ZERO_ADDRESS,
           tokenAmount: '0',
           tokenGas: '0',
-          enableQos: 'false'
+          enableQos: false
         },
         relayData: {
           gasPrice,

--- a/test/Verifiers.test.ts
+++ b/test/Verifiers.test.ts
@@ -71,7 +71,7 @@ contract('DeployVerifier', function ([relayHub, other1, relayWorker, verifierOwn
         tokenContract: token.address,
         tokenAmount: tokensPaid.toString(),
         tokenGas: '50000',
-        enableQos: 'false',
+        enableQos: false
       },
       relayData: {
         gasPrice,
@@ -223,7 +223,7 @@ contract('RelayVerifier', function ([relayHub, relayWorker, other, verifierOwner
         tokenContract: token.address,
         tokenAmount: tokensPaid.toString(),
         tokenGas: '50000',
-        enableQos: 'false',
+        enableQos: false
       },
       relayData: {
         gasPrice,
@@ -246,7 +246,7 @@ contract('RelayVerifier', function ([relayHub, relayWorker, other, verifierOwner
         tokenContract: relayHub, // relayHub is an address not authorized as token contract
         tokenAmount: tokensPaid.toString(),
         tokenGas: '50000',
-        enableQos: 'false',
+        enableQos: false
       },
       relayData: {
         gasPrice,

--- a/test/Verifiers.test.ts
+++ b/test/Verifiers.test.ts
@@ -70,7 +70,8 @@ contract('DeployVerifier', function ([relayHub, other1, relayWorker, verifierOwn
         index: index,
         tokenContract: token.address,
         tokenAmount: tokensPaid.toString(),
-        tokenGas: '50000'
+        tokenGas: '50000',
+        enableQos: 'false',
       },
       relayData: {
         gasPrice,
@@ -221,7 +222,8 @@ contract('RelayVerifier', function ([relayHub, relayWorker, other, verifierOwner
         gas: gasLimit,
         tokenContract: token.address,
         tokenAmount: tokensPaid.toString(),
-        tokenGas: '50000'
+        tokenGas: '50000',
+        enableQos: 'false',
       },
       relayData: {
         gasPrice,
@@ -243,7 +245,8 @@ contract('RelayVerifier', function ([relayHub, relayWorker, other, verifierOwner
         gas: gasLimit,
         tokenContract: relayHub, // relayHub is an address not authorized as token contract
         tokenAmount: tokensPaid.toString(),
-        tokenGas: '50000'
+        tokenGas: '50000',
+        enableQos: 'false',
       },
       relayData: {
         gasPrice,

--- a/test/WalletFactory.test.ts
+++ b/test/WalletFactory.test.ts
@@ -46,6 +46,7 @@ contract('CustomSmartWalletFactory', ([from]) => {
       tokenContract: constants.ZERO_ADDRESS,
       tokenAmount: '0',
       tokenGas: '60000',
+      enableQos: 'false',
       recoverer: constants.ZERO_ADDRESS,
       index: '0'
     },
@@ -657,6 +658,7 @@ contract('SmartWalletFactory', ([from]) => {
       tokenContract: constants.ZERO_ADDRESS,
       tokenAmount: '1',
       tokenGas: '50000',
+      enableQos: 'false',
       recoverer: constants.ZERO_ADDRESS,
       index: '0'
     },

--- a/test/WalletFactory.test.ts
+++ b/test/WalletFactory.test.ts
@@ -46,7 +46,7 @@ contract('CustomSmartWalletFactory', ([from]) => {
       tokenContract: constants.ZERO_ADDRESS,
       tokenAmount: '0',
       tokenGas: '60000',
-      enableQos: 'false',
+      enableQos: false,
       recoverer: constants.ZERO_ADDRESS,
       index: '0'
     },
@@ -658,7 +658,7 @@ contract('SmartWalletFactory', ([from]) => {
       tokenContract: constants.ZERO_ADDRESS,
       tokenAmount: '1',
       tokenGas: '50000',
-      enableQos: 'false',
+      enableQos: false,
       recoverer: constants.ZERO_ADDRESS,
       index: '0'
     },

--- a/test/penalizer/Penalizer.test.ts
+++ b/test/penalizer/Penalizer.test.ts
@@ -1,0 +1,413 @@
+import { ether, expectRevert } from '@openzeppelin/test-helpers'
+
+import {
+  PenalizerInstance,
+  RelayHubInstance,
+  SmartWalletInstance,
+  TestRecipientInstance,
+  TestTokenInstance
+} from '../../types/truffle-contracts'
+
+import { createSmartWallet, createSmartWalletFactory, deployHub, getGaslessAccount, getTestingEnvironment } from '../TestUtils'
+import { AccountKeypair } from '../../src/relayclient/AccountManager'
+import { zeroAddress } from 'ethereumjs-util'
+import { createRawTx, fundAccount, currentTimeInSeconds, RelayHelper } from './Utils'
+import { fail } from 'assert'
+import { toBN } from 'web3-utils'
+import { TransactionReceipt } from 'web3-core'
+import { RelayRequest } from '../../src/common/EIP712/RelayRequest'
+
+const Penalizer = artifacts.require('Penalizer')
+const SmartWallet = artifacts.require('SmartWallet')
+const TestRecipient = artifacts.require('TestRecipient')
+const testToken = artifacts.require('TestToken')
+const TestVerifierEverythingAccepted = artifacts.require('TestVerifierEverythingAccepted')
+
+contract('Penalizer', function ([relayOwner, relayWorker, relayManager, otherAccount, fundedAccount]) {
+  // contracts
+  let relayHub: RelayHubInstance
+  let penalizer: PenalizerInstance
+  let recipient: TestRecipientInstance
+  let forwarder: SmartWalletInstance
+  let token: TestTokenInstance
+
+  let sender: AccountKeypair // wallet owner and relay request origin
+
+  let relayHelper: RelayHelper
+
+  const gasPrice = '1'
+  const txGas = 4e6
+  let chainId: number
+
+  before(async function () {
+    const env = await getTestingEnvironment()
+    chainId = env.chainId
+
+    // set up contracts
+    penalizer = await Penalizer.new()
+    relayHub = await deployHub(penalizer.address)
+    await penalizer.setHub(relayHub.address, { from: await penalizer.owner() })
+    recipient = await TestRecipient.new()
+    const verifier = await TestVerifierEverythingAccepted.new()
+    const smartWalletTemplate = await SmartWallet.new()
+    token = await testToken.new()
+
+    sender = await getGaslessAccount() // sender should be able to relay without funds
+
+    // smart wallet
+    const factory = await createSmartWalletFactory(smartWalletTemplate)
+    forwarder = await createSmartWallet(relayOwner, sender.address, factory, sender.privateKey, env.chainId)
+
+    // relay helper class
+    relayHelper = new RelayHelper(relayHub, relayOwner, relayWorker, relayManager, forwarder, verifier, token, env.chainId)
+    await relayHelper.init()
+  })
+
+  describe('should be able to have its hub set', function () {
+    before(async function () {
+      await penalizer.setHub(zeroAddress(), { from: await penalizer.owner() })
+    })
+    it('starting out with an unset address', async function () {
+      assert.equal(await penalizer.getHub(), zeroAddress(), 'penalizer hub does not match zero address')
+    })
+
+    it('successfully from its owner address', async function () {
+      await penalizer.setHub(relayHub.address, { from: await penalizer.owner() })
+
+      assert.equal(await penalizer.getHub(), relayHub.address, 'penalizer hub does not match relay hub')
+    })
+
+    it('unsuccessfully from another address', async function () {
+      await expectRevert(
+        penalizer.setHub(otherAccount, { from: otherAccount }),
+        'caller is not the owner'
+      )
+
+      // hub should remain set with its previous value
+      assert.equal(await penalizer.getHub(), relayHub.address, 'penalizer hub did not keep its relay hub value')
+    })
+  })
+
+  describe('should fulfill transactions', function () {
+    it('unsuccessfully if qos is disabled', async function () {
+      const [rr, sig] = await createRelayRequestAndSignature({ relayData: '0xdeadbeef01', enableQos: false })
+
+      await relayHub.relayCall(rr, sig, {
+        from: relayWorker,
+        gas: txGas,
+        gasPrice: gasPrice
+      })
+
+      assert.isFalse(await penalizer.fulfilled(sig), 'tx relayed without qos is fulfilled')
+    })
+
+    it('successfully if qos is enabled', async function () {
+      const [rr, sig] = await createRelayRequestAndSignature({ relayData: '0xdeadbeef02', enableQos: true })
+
+      await relayHub.relayCall(rr, sig, {
+        from: relayWorker,
+        gas: txGas,
+        gasPrice: gasPrice
+      })
+
+      assert.isTrue(await penalizer.fulfilled(sig), 'tx relayed with qos is not fulfilled')
+    })
+  })
+
+  describe('should reject claims', function () {
+    it('due to hub not being set', async function () {
+      const hublessPenalizer = await Penalizer.new()
+
+      const [rr, sig] = await createRelayRequestAndSignature({ relayData: '0xdeadbeef03' })
+      const receipt = relayHelper.createReceipt(rr, sig)
+
+      await expectRevert(
+        hublessPenalizer.claim(receipt),
+        'relay hub not set'
+      )
+    })
+
+    it('due to receiving a commitment with qos disabled', async function () {
+      const [rr, sig] = await createRelayRequestAndSignature({ relayData: '0xdeadbeef04', enableQos: false })
+      const receipt = relayHelper.createReceipt(rr, sig)
+
+      await expectRevert(
+        penalizer.claim(receipt),
+        'commitment without QoS'
+      )
+    })
+
+    it('due to missing signature', async function () {
+      const [rr, sig] = await createRelayRequestAndSignature({ relayData: '0xdeadbeef05', enableQos: true })
+      const receipt = relayHelper.createReceipt(rr, sig)
+
+      await expectRevert(
+        penalizer.claim(receipt),
+        'worker signature mismatch'
+      )
+    })
+
+    it('due to forged signature', async function () {
+      const [rr, sig] = await createRelayRequestAndSignature({ relayData: '0xdeadbeef06', enableQos: true })
+      const receipt = relayHelper.createReceipt(rr, sig)
+      receipt.workerSignature = web3.utils.randomHex(130)
+
+      await expectRevert(
+        penalizer.claim(receipt),
+        'worker signature mismatch'
+      )
+    })
+
+    it('due to worker address mismatch', async function () {
+      const [rr, sig] = await createRelayRequestAndSignature({ relayData: '0xdeadbeef07', enableQos: true })
+      const receipt = relayHelper.createReceipt(rr, sig)
+      receipt.commitment.relayWorker = otherAccount // tamper with receipt worker
+      await relayHelper.signReceipt(receipt)
+
+      await expectRevert(
+        penalizer.claim(receipt),
+        'worker address does not match'
+      )
+    })
+
+    it('due to relay hub mismatch', async function () {
+      const [rr, sig] = await createRelayRequestAndSignature({ relayData: '0xdeadbeef07', enableQos: true })
+      const receipt = relayHelper.createReceipt(rr, sig)
+      receipt.commitment.relayHubAddress = otherAccount // tamper with receipt hub
+      await relayHelper.signReceipt(receipt)
+
+      await expectRevert(
+        penalizer.claim(receipt),
+        'relay hub does not match'
+      )
+    })
+
+    it('due to claim not being made by commitment receiver', async function () {
+      const [rr, sig] = await createRelayRequestAndSignature({ relayData: '0xdeadbeef08', enableQos: true })
+      const receipt = relayHelper.createReceipt(rr, sig)
+      await relayHelper.signReceipt(receipt)
+
+      await expectRevert(
+        penalizer.claim(receipt, { from: otherAccount }),
+        'receiver must claim commitment'
+      )
+    })
+  })
+
+  describe('should receive claims', function () {
+    before(async function () {
+      // sender will need to be funded to complete claim calls
+      await fundAccount(fundedAccount, sender.address, '10')
+    })
+
+    // from this point onwards txs must be put together manually since the sender account is locked
+
+    it('and reject them if tx is fulfilled', async function () {
+      const [rr, sig] = await createRelayRequestAndSignature({ relayData: '0xdeadbeef09', enableQos: true })
+
+      // if tx is successfully relayed, it will be marked as fulfilled
+      await relayHub.relayCall(rr, sig, {
+        from: relayWorker,
+        gas: txGas,
+        gasPrice: gasPrice
+      })
+
+      const receipt = relayHelper.createReceipt(rr, sig)
+      await relayHelper.signReceipt(receipt)
+
+      const rawTx = await createRawTx(
+        sender,
+        penalizer.address,
+        penalizer.contract.methods.claim(receipt).encodeABI(),
+        txGas.toString(),
+        gasPrice,
+        chainId
+      )
+
+      await assertTransactionFails(rawTx, "can't penalize fulfilled tx")
+    })
+
+    it('and accept them if tx is unfulfilled and unpenalized', async function () {
+      const [rr, sig] = await createRelayRequestAndSignature({ relayData: '0xdeadbeef10', enableQos: true })
+      const receipt = relayHelper.createReceipt(rr, sig)
+      await relayHelper.signReceipt(receipt)
+
+      // in this case, the worker signed a commitment without relaying the corresponding tx first
+      // this means a claim would be valid, and penalization should take place
+      const rawTx = await createRawTx(
+        sender,
+        penalizer.address,
+        penalizer.contract.methods.claim(receipt).encodeABI(),
+        txGas.toString(),
+        gasPrice,
+        chainId
+      )
+
+      await assertStakeIsBurned(relayHub, relayManager, sender, rawTx)
+    })
+
+    it('and reject them if tx is unfulfilled but penalized', async function () {
+      // same as previous test case
+      const [rr, sig] = await createRelayRequestAndSignature({ relayData: '0xdeadbeef10', enableQos: true })
+      const receipt = relayHelper.createReceipt(rr, sig)
+      await relayHelper.signReceipt(receipt)
+
+      // attempt to repeat previously successful claim
+      // a claim would be invalid here since tx has already been penalized
+      const rawTx = await createRawTx(
+        sender,
+        penalizer.address,
+        penalizer.contract.methods.claim(receipt).encodeABI(),
+        txGas.toString(),
+        gasPrice,
+        chainId
+      )
+
+      await assertTransactionFails(rawTx, 'tx already penalized')
+    })
+  })
+
+  describe('should receive claims according with the commitment time', function () {
+    describe('and accept them', () => {
+      beforeEach(async () => {
+        await relayHub.stakeForAddress(relayManager, 1000, {
+          from: relayOwner,
+          value: ether('1'),
+          gasPrice: gasPrice
+        })
+      })
+
+      const allowedCommitmentTimes = [
+        // due to security implications, we accept up to 15 secs of delay
+        // but we cannot test for the exact time
+        10,
+        0,
+        // set a past commitment time
+        -100,
+        -150
+      ]
+      allowedCommitmentTimes.forEach((timeDiff, index) => {
+        it(`when the commit time is ${Math.abs(timeDiff)} seconds in the ${timeDiff < 0 ? 'past' : 'future'}`, async function () {
+          const [rr, sig] = await createRelayRequestAndSignature({ relayData: `0xdeadbeef2${index}`, enableQos: true })
+          const receipt = relayHelper.createReceipt(rr, sig, currentTimeInSeconds() + timeDiff)
+          await relayHelper.signReceipt(receipt)
+
+          const rawTx = await createRawTx(
+            sender,
+            penalizer.address,
+            penalizer.contract.methods.claim(receipt).encodeABI(),
+            txGas.toString(),
+            gasPrice,
+            chainId
+          )
+          await assertStakeIsBurned(relayHub, relayManager, sender, rawTx)
+        })
+      })
+    })
+
+    describe('and reject them', () => {
+      // commitment time not yet expired, unsuccessful claims
+      // if we set a small future time, the claims can be successful
+      // due to the 15 seconds of delay we accept.
+      const forbiddenCommitmentTime = [
+        60,
+        150,
+        250,
+        350
+      ]
+      forbiddenCommitmentTime.forEach((timeDiff, index) => {
+        it(`when the commit time is ${timeDiff} seconds in the future`, async function () {
+          const [rr, sig] = await createRelayRequestAndSignature({ relayData: `0xdeadbeef3${index}`, enableQos: true })
+          const receipt = relayHelper.createReceipt(rr, sig, currentTimeInSeconds() + timeDiff)
+          await relayHelper.signReceipt(receipt)
+
+          const rawTx = await createRawTx(
+            sender,
+            penalizer.address,
+            penalizer.contract.methods.claim(receipt).encodeABI(),
+            txGas.toString(),
+            gasPrice,
+            chainId
+          )
+
+          await assertTransactionFails(rawTx, 'too early to claim')
+        })
+      })
+    })
+  })
+
+  it('claim should fail if no stake has been added back', async () => {
+    // the stack previously added has been burned from previous successful claims
+    const [rr, sig] = await createRelayRequestAndSignature({ relayData: '0xdeadbeef11', enableQos: true })
+    const receipt = relayHelper.createReceipt(rr, sig)
+    await relayHelper.signReceipt(receipt)
+
+    const rawTx = await createRawTx(
+      sender,
+      penalizer.address,
+      penalizer.contract.methods.claim(receipt).encodeABI(),
+      txGas.toString(),
+      gasPrice,
+      chainId
+    )
+
+    await assertTransactionFails(rawTx)
+  })
+
+  interface RelayRequestParams{
+    relayData: string
+    enableQos?: boolean
+  }
+
+  async function createRelayRequestAndSignature (params: RelayRequestParams): Promise<[RelayRequest, string]> {
+    const rr = await relayHelper.createRelayRequest({
+      from: sender.address,
+      to: recipient.address,
+      relayData: params.relayData,
+      enableQos: params.enableQos ?? false
+    })
+    const sig = relayHelper.getRelayRequestSignature(rr, sender)
+
+    return [rr, sig]
+  }
+})
+
+async function assertTransactionFails (rawTx: string, reason?: string): Promise<void> {
+  try {
+    await web3.eth.sendSignedTransaction(rawTx)
+    fail("expected claim to fail, but it didn't")
+  } catch (err) {
+    if (reason === undefined || reason === null) {
+      // we don't want to check why the transaction failed, but only if failed or not.
+      return
+    }
+    if (!(err instanceof Error)) {
+      fail('Unknown error')
+    }
+    assert.isTrue(err.message.includes(reason), `unexpected revert reason: ${err.message}`)
+  }
+}
+
+async function assertStakeIsBurned (relayHub: RelayHubInstance, relayManager: string, sender: AccountKeypair, rawTx: string): Promise<void> {
+  let stakeInfo = await relayHub.getStakeInfo(relayManager)
+  let stake = toBN(stakeInfo.stake)
+  const balanceBefore = toBN(await web3.eth.getBalance(sender.address))
+  const toBurn = stake.div(toBN(2))
+  const reward = stake.sub(toBurn)
+
+  let txReceipt: TransactionReceipt
+  try {
+    txReceipt = await web3.eth.sendSignedTransaction(rawTx)
+  } catch (err) {
+    fail(err)
+  }
+
+  stakeInfo = await relayHub.getStakeInfo(relayManager)
+  stake = toBN(stakeInfo.stake)
+
+  const balanceAfter = toBN(await web3.eth.getBalance(sender.address))
+  const gasUsed = toBN(txReceipt.gasUsed)
+
+  assert.isTrue(stake.eq(toBN(0)), 'stake was not burned')
+  assert.isTrue(balanceAfter.eq(balanceBefore.add(reward).sub(gasUsed)), 'unexpected beneficiary balance after claim')
+}

--- a/test/penalizer/Utils.ts
+++ b/test/penalizer/Utils.ts
@@ -1,0 +1,174 @@
+import { ether } from '@openzeppelin/test-helpers'
+import { Transaction } from 'ethereumjs-tx'
+import { ethers } from 'ethers'
+import { toChecksumAddress } from 'web3-utils'
+import { RelayRequest } from '../../src/common/EIP712/RelayRequest'
+import TypedRequestData, { getDomainSeparatorHash } from '../../src/common/EIP712/TypedRequestData'
+import { Commitment } from '../../src/enveloping/Commitment'
+import { AccountKeypair } from '../../src/relayclient/AccountManager'
+import { Address } from '../../src/relayclient/types/Aliases'
+import { RelayHubInstance, TestVerifierEverythingAcceptedInstance, TestTokenInstance, IForwarderInstance } from '../../types/truffle-contracts'
+import { getLocalEip712Signature } from '../../Utils'
+
+const gasPrice = '1'
+
+interface RelayRequestParams{
+  from: Address
+  to: Address
+  relayData: string
+  enableQos: boolean
+}
+
+interface CommitmentReceipt {
+  workerAddress: string | BN
+  commitment: {
+    time: number | BN | string
+    from: string | BN
+    to: string | BN
+    relayHubAddress: string | BN
+    relayWorker: string | BN
+    enableQos: boolean
+    data: string
+    signature: string
+  }
+  workerSignature: string
+}
+
+export class RelayHelper {
+  relayHub: RelayHubInstance
+  relayOwner: Address
+  relayWorker: Address
+  relayManager: Address
+  forwarder: IForwarderInstance
+  verifier: TestVerifierEverythingAcceptedInstance
+  token: TestTokenInstance
+  chainId: number
+
+  constructor (
+    relayHub: RelayHubInstance,
+    relayOwner: Address,
+    relayWorker: Address,
+    relayManager: Address,
+    forwarder: IForwarderInstance,
+    verifier: TestVerifierEverythingAcceptedInstance,
+    token: TestTokenInstance,
+    chainId: number
+  ) {
+    this.relayHub = relayHub
+    this.relayOwner = relayOwner
+    this.relayWorker = relayWorker
+    this.relayManager = relayManager
+    this.forwarder = forwarder
+    this.verifier = verifier
+    this.token = token
+    this.chainId = chainId
+  }
+
+  async init (): Promise<void> {
+    await this.token.mint('1000', this.forwarder.address)
+
+    await this.relayHub.stakeForAddress(this.relayManager, 1000, {
+      from: this.relayOwner,
+      value: ether('1'),
+      gasPrice: gasPrice
+    })
+
+    await this.relayHub.addRelayWorkers([this.relayWorker], { from: this.relayManager, gasPrice: gasPrice })
+  }
+
+  async createRelayRequest (params: RelayRequestParams): Promise<RelayRequest> {
+    return {
+      request: {
+        relayHub: this.relayHub.address,
+        to: params.to,
+        data: params.relayData,
+        from: params.from,
+        nonce: (await this.forwarder.nonce()).toString(),
+        value: '0',
+        gas: '3000000',
+        tokenContract: this.token.address,
+        tokenAmount: '1',
+        tokenGas: '50000',
+        enableQos: params.enableQos
+      },
+      relayData: {
+        gasPrice: gasPrice,
+        relayWorker: this.relayWorker,
+        callForwarder: this.forwarder.address,
+        callVerifier: this.verifier.address,
+        domainSeparator: getDomainSeparatorHash(this.forwarder.address, this.chainId)
+      }
+    }
+  }
+
+  getRelayRequestSignature (relayRequest: RelayRequest, account: AccountKeypair): string {
+    const dataToSign = new TypedRequestData(
+      this.chainId,
+      this.forwarder.address,
+      relayRequest
+    )
+    return getLocalEip712Signature(
+      dataToSign,
+      account.privateKey
+    )
+  }
+
+  createReceipt (relayRequest: RelayRequest, signature: string, time?: number): CommitmentReceipt {
+    const request = relayRequest.request
+    const relayData = relayRequest.relayData
+    return {
+      workerAddress: relayData.relayWorker,
+      commitment: {
+        time: time ?? currentTimeInSeconds(),
+        from: request.from,
+        to: request.to,
+        data: request.data,
+        relayHubAddress: this.relayHub.address,
+        relayWorker: relayData.relayWorker,
+        enableQos: request.enableQos,
+        signature: signature
+      },
+      workerSignature: '0x00'
+    }
+  }
+
+  async signReceipt (commitmentReceipt: CommitmentReceipt): Promise<void> {
+    const c = commitmentReceipt.commitment
+    const commitment = new Commitment(c.time as Number, c.from as string, c.to as string, c.data, c.relayHubAddress as string, c.relayWorker as string, c.enableQos, c.signature)
+    const hash = ethers.utils.keccak256(commitment.encodeForSign())
+
+    commitmentReceipt.workerAddress = toChecksumAddress(this.relayWorker)
+    commitmentReceipt.workerSignature = await web3.eth.sign(hash, this.relayWorker)
+  }
+}
+
+export async function createRawTx (from: AccountKeypair, to: Address, data: string, gas: string, gasPrice: string, chainId: number): Promise<string> {
+  const txCount = await web3.eth.getTransactionCount(from.address)
+
+  const txObject = {
+    from: from.address,
+    to: to,
+    data: data,
+    gas: web3.utils.toHex(gas),
+    gasPrice: web3.utils.toHex(gasPrice),
+    nonce: web3.utils.toHex(txCount)
+  }
+
+  const tx = new Transaction(txObject, { chainId: chainId })
+  tx.sign(from.privateKey)
+
+  return '0x' + tx.serialize().toString('hex')
+}
+
+export async function fundAccount (fundedAccount: Address, destination: Address, ethAmount: string): Promise<void> {
+  await web3.eth.sendTransaction({
+    from: fundedAccount,
+    to: destination,
+    value: web3.utils.toWei(ethAmount, 'ether'),
+    gasPrice: gasPrice
+  })
+}
+
+export function currentTimeInSeconds (): number {
+  return Math.floor(Date.now() / 1000)
+}

--- a/test/relayclient/AccountManager.test.ts
+++ b/test/relayclient/AccountManager.test.ts
@@ -113,7 +113,8 @@ contract('AccountManager', function (accounts) {
         gas: '1',
         tokenContract: constants.ZERO_ADDRESS,
         tokenAmount: '0',
-        tokenGas: '0'
+        tokenGas: '0',
+        enableQos: 'false'
       },
       relayData: {
         gasPrice: '1',

--- a/test/relayclient/AccountManager.test.ts
+++ b/test/relayclient/AccountManager.test.ts
@@ -114,7 +114,7 @@ contract('AccountManager', function (accounts) {
         tokenContract: constants.ZERO_ADDRESS,
         tokenAmount: '0',
         tokenGas: '0',
-        enableQos: 'false'
+        enableQos: false
       },
       relayData: {
         gasPrice: '1',

--- a/test/relayclient/KnownRelaysManager.test.ts
+++ b/test/relayclient/KnownRelaysManager.test.ts
@@ -15,7 +15,6 @@ import sinon from 'sinon'
 import { ChildProcessWithoutNullStreams } from 'child_process'
 import { RelayRegisteredEventInfo } from '../../src/relayclient/types/RelayRegisteredEventInfo'
 import { Environment } from '../../src/common/Environments'
-import { constants } from '../../src/common/Constants'
 import { AccountKeypair } from '../../src/relayclient/AccountManager'
 import EnvelopingTransactionDetails from '../../src/relayclient/types/EnvelopingTransactionDetails'
 
@@ -69,7 +68,7 @@ contract('KnownRelaysManager', function (
       workerRelayWorkersAdded = await web3.eth.personal.newAccount('password')
       workerRelayServerRegistered = await web3.eth.personal.newAccount('password')
       workerNotActive = await web3.eth.personal.newAccount('password')
-      relayHub = await deployHub(constants.ZERO_ADDRESS)
+      relayHub = await deployHub()
       config = configure({
         relayHubAddress: relayHub.address,
         relayLookupWindowBlocks,
@@ -188,7 +187,7 @@ contract('KnownRelaysManager 2', function (accounts) {
 
     before(async function () {
       env = await getTestingEnvironment()
-      relayHub = await deployHub(constants.ZERO_ADDRESS)
+      relayHub = await deployHub()
       config = configure({
         preferredRelays: ['http://localhost:8090'],
         relayHubAddress: relayHub.address,

--- a/test/relayclient/RelayClient.test.ts
+++ b/test/relayclient/RelayClient.test.ts
@@ -859,7 +859,8 @@ gasOptions.forEach(gasOption => {
           data,
           relayHub.address,
           relayWorkerAddress,
-          'false'
+          'false',
+          INCORRECT_ECDSA_SIGNATURE
         )
         badCommitmentReceipt = {
           commitment: commitment,

--- a/test/relayclient/RelayClient.test.ts
+++ b/test/relayclient/RelayClient.test.ts
@@ -355,7 +355,7 @@ gasOptions.forEach(gasOption => {
             tokenContract: token.address,
             tokenAmount: '1',
             tokenGas: tokenPaymentEstimate.toString(),
-            enableQos: 'false',
+            enableQos: false,
             recoverer: constants.ZERO_ADDRESS,
             index: '0'
           },
@@ -860,7 +860,7 @@ gasOptions.forEach(gasOption => {
           data,
           relayHub.address,
           relayWorkerAddress,
-          'false',
+          false,
           INCORRECT_ECDSA_SIGNATURE
         )
         badCommitmentReceipt = {

--- a/test/relayclient/RelayClient.test.ts
+++ b/test/relayclient/RelayClient.test.ts
@@ -355,6 +355,7 @@ gasOptions.forEach(gasOption => {
             tokenContract: token.address,
             tokenAmount: '1',
             tokenGas: tokenPaymentEstimate.toString(),
+            enableQos: 'false',
             recoverer: constants.ZERO_ADDRESS,
             index: '0'
           },

--- a/test/relayclient/RelayProvider.test.ts
+++ b/test/relayclient/RelayProvider.test.ts
@@ -61,7 +61,7 @@ contract('RelayProvider', function (accounts) {
     sender = accounts[0]
     gaslessAccount = await getGaslessAccount()
     web3 = new Web3(underlyingProvider)
-    relayHub = await deployHub(constants.ZERO_ADDRESS)
+    relayHub = await deployHub()
 
     sWalletTemplate = await SmartWallet.new()
     const env = (await getTestingEnvironment())

--- a/test/relayclient/RelayProvider.test.ts
+++ b/test/relayclient/RelayProvider.test.ts
@@ -24,7 +24,7 @@ import {
   TestTokenInstance
 } from '../../types/truffle-contracts'
 import { isRsk } from '../../src/common/Environments'
-import { deployHub, startRelay, stopRelay, getTestingEnvironment, createSmartWalletFactory, createSmartWallet, getGaslessAccount, prepareTransaction, RelayServerData } from '../TestUtils'
+import { deployHub, startRelay, stopRelay, getTestingEnvironment, createSmartWalletFactory, createSmartWallet, getGaslessAccount, prepareTransaction, RelayServerData, getHostnameFromProvider } from '../TestUtils'
 import BadRelayClient from '../dummies/BadRelayClient'
 
 // @ts-ignore
@@ -114,7 +114,7 @@ contract('RelayProvider', function (accounts) {
       let websocketProvider: WebsocketProvider
 
       if (isRsk(await getTestingEnvironment())) {
-        websocketProvider = new Web3.providers.WebsocketProvider('ws://localhost:4445/websocket')
+        websocketProvider = new Web3.providers.WebsocketProvider(`ws://${getHostnameFromProvider()}:4445/websocket`)
       } else {
         websocketProvider = new Web3.providers.WebsocketProvider(underlyingProvider.host)
       }
@@ -837,7 +837,7 @@ contract('RelayProvider', function (accounts) {
       let websocketProvider: WebsocketProvider
 
       if (isRsk(await getTestingEnvironment())) {
-        websocketProvider = new Web3.providers.WebsocketProvider('ws://localhost:4445/websocket')
+        websocketProvider = new Web3.providers.WebsocketProvider(`ws://${getHostnameFromProvider()}:4445/websocket`)
       } else {
         websocketProvider = new Web3.providers.WebsocketProvider(underlyingProvider.host)
       }

--- a/test/relayclient/RelaySelectionManager.test.ts
+++ b/test/relayclient/RelaySelectionManager.test.ts
@@ -10,7 +10,6 @@ import { PartialRelayInfo } from '../../src/relayclient/types/RelayInfo'
 import { register, stake } from './KnownRelaysManager.test'
 import PingResponse from '../../src/common/PingResponse'
 import { deployHub, getTestingEnvironment } from '../TestUtils'
-import { constants } from '../../src/common/Constants'
 import EnvelopingTransactionDetails from '../../src/relayclient/types/EnvelopingTransactionDetails'
 
 const { expect, assert } = require('chai').use(chaiAsPromised)
@@ -102,7 +101,7 @@ contract('RelaySelectionManager', async function (accounts) {
 
       before(async function () {
         chainId = (await getTestingEnvironment()).chainId
-        relayHub = await deployHub(constants.ZERO_ADDRESS)
+        relayHub = await deployHub()
         await stake(relayHub, relayManager, accounts[0])
         await register(relayHub, relayManager, accounts[2], preferredRelayUrl)
 

--- a/test/relayclient/SmartWalletDiscovery.test.ts
+++ b/test/relayclient/SmartWalletDiscovery.test.ts
@@ -12,6 +12,7 @@ import { toChecksumAddress } from 'web3-utils'
 import { constants } from '../../src/common/Constants'
 import { Address } from '../../src/relayclient/types/Aliases'
 import { WebsocketProvider } from 'web3-core'
+import { getHostnameFromProvider } from '../TestUtils'
 
 const CustomSmartWallet = artifacts.require('CustomSmartWallet')
 const SmartWallet = artifacts.require('SmartWallet')
@@ -1135,7 +1136,7 @@ contract('SmartWalletDiscovery', function (accounts) {
   }
 
   async function init (isCustom: boolean): Promise<void> {
-    socketProvider = new Web3.providers.WebsocketProvider('ws://127.0.0.1:4445/websocket')
+    socketProvider = new Web3.providers.WebsocketProvider(`ws://${getHostnameFromProvider()}:4445/websocket`)
 
     CustomSmartWalletFactory.setProvider(socketProvider, undefined)
     SmartWalletFactory.setProvider(socketProvider, undefined)

--- a/test/relayserver/ServerTestEnvironment.ts
+++ b/test/relayserver/ServerTestEnvironment.ts
@@ -106,7 +106,7 @@ export class ServerTestEnvironment {
    * different provider from the contract interactor itself.
    */
   async init (clientConfig: Partial<EnvelopingConfig> = {}, relayHubConfig: Partial<RelayHubConfiguration> = {}, contractFactory?: (clientConfig: Partial<EnvelopingConfig>) => Promise<ContractInteractor>): Promise<void> {
-    this.relayHub = await deployHub(undefined, relayHubConfig)
+    this.relayHub = await deployHub(relayHubConfig)
     this.recipient = await TestRecipient.new()
     this.relayVerifier = await TestVerifierEverythingAccepted.new()
     this.deployVerifier = await TestDeployVerifierEverythingAccepted.new()

--- a/test/smartwallet/CustomSmartWallet.test.ts
+++ b/test/smartwallet/CustomSmartWallet.test.ts
@@ -45,7 +45,8 @@ function createRequest (request: Partial<ForwardRequest>, relayData: Partial<Rel
       data: '0x',
       tokenContract: constants.ZERO_ADDRESS,
       tokenAmount: '1',
-      tokenGas: '50000'
+      tokenGas: '50000',
+      enableQos: 'false',
     },
     relayData: {
       gasPrice: '1',

--- a/test/smartwallet/CustomSmartWallet.test.ts
+++ b/test/smartwallet/CustomSmartWallet.test.ts
@@ -46,7 +46,7 @@ function createRequest (request: Partial<ForwardRequest>, relayData: Partial<Rel
       tokenContract: constants.ZERO_ADDRESS,
       tokenAmount: '1',
       tokenGas: '50000',
-      enableQos: false,
+      enableQos: false
     },
     relayData: {
       gasPrice: '1',

--- a/test/smartwallet/CustomSmartWallet.test.ts
+++ b/test/smartwallet/CustomSmartWallet.test.ts
@@ -46,7 +46,7 @@ function createRequest (request: Partial<ForwardRequest>, relayData: Partial<Rel
       tokenContract: constants.ZERO_ADDRESS,
       tokenAmount: '1',
       tokenGas: '50000',
-      enableQos: 'false',
+      enableQos: false,
     },
     relayData: {
       gasPrice: '1',

--- a/test/smartwallet/SmartWallet.test.ts
+++ b/test/smartwallet/SmartWallet.test.ts
@@ -121,7 +121,8 @@ options.forEach(element => {
           data: '0x',
           tokenContract: constants.ZERO_ADDRESS,
           tokenAmount: '1',
-          tokenGas: '50000'
+          tokenGas: '50000',
+          enableQos: 'false',
         },
         relayData: {
           gasPrice: '1',

--- a/test/smartwallet/SmartWallet.test.ts
+++ b/test/smartwallet/SmartWallet.test.ts
@@ -122,7 +122,7 @@ options.forEach(element => {
           tokenContract: constants.ZERO_ADDRESS,
           tokenAmount: '1',
           tokenGas: '50000',
-          enableQos: 'false',
+          enableQos: false
         },
         relayData: {
           gasPrice: '1',


### PR DESCRIPTION
This PR implements the first iteration for issue [PP-3](https://rsklabs.atlassian.net/browse/PP-3), which is implementing the Arbiter Smart contract based on the existing Penalizer.

## Design
Please refer to the following document: [Arbiter contract design](https://docs.google.com/document/d/1q7iEwxmjCAZSZ95Mdc8jXStnw5r23YJBPmgk7c79YB8).

## Overview
- a new `enableQos` field has been added to Relay and Deploy Requests. it allows relays to be marked as fulfilled when completed (and makes them penalizable if they are not)
  - relay requests that do not have QoS enabled are not tracked in terms of whether they have been fulfilled or not, and therefore cannot be penalized 
  - for now this field is set as false for new tests ([PP-23](https://rsklabs.atlassian.net/browse/PP-23) is adding unit tests for this feature)
- the Penalizer contract now has a hub field which is set after deployment
  - this field allows the contract to call the Hub if a stake must be burnt after a valid penalization claim
  - only the Penalizer owner can set the hub
  - there is also a hub getter method 
- the Penalizer contract has a `fulfill` method to mark a QoS-enabled relay as fulfilled
  - the Relay Hub contract calls the Penalizer after each successful relay in order to do this
  - there is also a view method for checking if a relay is fulfilled or not (in this context, relays are identified by their tx sig)
- the Penalizer contract has a `claim` method that receives a commitment which the callee believes has been unmet
  - if a relay commitment is claimed (because of apparent infringement) and the Penalizer does not have it marked as fulfilled, then penalization will take place through a call to the Hub contract  