### PR TITLE
PP-34: update RSKj snapshot version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ parameters:
         default: "rsksmart/rskj.git"
     version:
         type: string
-        default: "3.0.0-SNAPSHOT"
+        default: "3.1.0-SNAPSHOT"
     branch:
         type: string
         default: "master"


### PR DESCRIPTION
This PR updates the RSKj snapshot version in order to prevent the Circle CI test suite execution from hanging.