### PR TITLE
Fix web socket connection problems

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,6 +12,7 @@ services:
         command: --regtest
         ports:
             - '127.0.0.1:4444:4444'
+            - '127.0.0.1:4445:4445'
         networks:
             - 'rif-relay-testing'
 

--- a/truffle.js
+++ b/truffle.js
@@ -60,7 +60,10 @@ module.exports = {
             onlyCalledMethods: true,
             showTimeSpent: true,
             excludeContracts: []
-        }
+        },
+        // value in ms 1_800_000 (= 1000 * 60 * 30 = 30 minutes), since that the default value 300_000 (= 5 mins) isn't enough
+        before_timeout: 1800000, // for before and before_all methods
+        timeout: 1800000 // for the tests
     },
     compilers: {
         solc: {


### PR DESCRIPTION
- Expose the web socket connection ports from RSKj node container
- Set a longer timeout for tests execution