### PR TITLE
PP-73: restrict typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "ts-node": "8.6.2",
     "typechain": "1.0.5",
     "typechain-target-trufflehotfix": "0.0.4-alpha",
-    "typescript": "^4.3.5",
+    "typescript": "4.3.5",
     "web3-provider-engine": "16.0.1",
     "webpack": "^5.43.0",
     "webpack-cli": "^4.7.2",


### PR DESCRIPTION
This PR restricts the typescript version used in the project to prevent build errors.

For now, we're OK with using the older version to move forward. [PP-75](https://rsklabs.atlassian.net/browse/PP-75) is a follow-up issue to properly fix these build errors.