### PR TITLE
PP-52: Comment out time check and document the reason behind that choice

### DIFF
--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -154,7 +154,7 @@ contract Penalizer is IPenalizer, Ownable {
          * - https://cryptomarketpool.com/block-timestamp-manipulation-attack/
          */
         /* solhint-disable-next-line not-rely-on-time */
-        require(commitmentReceipt.commitment.time <= block.timestamp, "too early to claim");
+        require(commitmentReceipt.commitment.time <= block.timestamp + 15, "too early to claim");
 
         bytes32 txId = keccak256(commitmentReceipt.commitment.signature);
         require(fulfilledTransactions[txId] == false, "can't penalize fulfilled tx");

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -143,7 +143,7 @@ contract Penalizer is IPenalizer, Ownable {
         require(hub == commitmentReceipt.commitment.relayHubAddress, "relay hub does not match");
         require(msg.sender == commitmentReceipt.commitment.from, "receiver must claim commitment");
         
-        /* Althout it could be a security flaws, in this case we don't need a strict
+        /* Although it could be a security flaw, in this case we don't need a strict
          * time check. We are aware that the miner could tamper the block.timestamp 
          * but right now the implementation of ethereum protocol would invalidate
          * blocks with more than 15 seconds in future. 

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -142,9 +142,19 @@ contract Penalizer is IPenalizer, Ownable {
         require(workerAddress == commitmentReceipt.commitment.relayWorker, "worker address does not match");
         require(hub == commitmentReceipt.commitment.relayHubAddress, "relay hub does not match");
         require(msg.sender == commitmentReceipt.commitment.from, "receiver must claim commitment");
-
-        // skip qos check for now
-        //require(commitmentReceipt.commitment.time <= block.timestamp, "too early to claim");
+        
+        /* Althout it could be a security flaws, in this case we don't need a strict
+         * time check. We are aware that the miner could tamper the block.timestamp 
+         * but right now the implementation of ethereum protocol would invalidate
+         * blocks with more than 15 seconds in future. 
+         * We can accept a variability of +/- 15 seconds, without being impacted by that.
+         * References:
+         * - https://consensys.github.io/smart-contract-best-practices/recommendations/#timestamp-dependence
+         * - https://swcregistry.io/docs/SWC-116
+         * - https://cryptomarketpool.com/block-timestamp-manipulation-attack/
+         */
+        /* solhint-disable-next-line not-rely-on-time */
+        require(commitmentReceipt.commitment.time <= block.timestamp, "too early to claim");
 
         bytes32 txId = keccak256(commitmentReceipt.commitment.signature);
         require(fulfilledTransactions[txId] == false, "can't penalize fulfilled tx");

--- a/test/penalizer/Penalizer.test.ts
+++ b/test/penalizer/Penalizer.test.ts
@@ -319,8 +319,10 @@ contract('Penalizer', function ([relayOwner, relayWorker, relayManager, otherAcc
     })
 
     // commitment time not yet expired, unsuccessful claims
+    // if we set a small future time, the claims can be successful
+    // due to the 15 seconds of delay we accept.
     const futureReceiptTime = [
-      50,
+      60,
       150,
       250,
       350
@@ -364,7 +366,6 @@ contract('Penalizer', function ([relayOwner, relayWorker, relayManager, otherAcc
   }
 })
 
-
 function getSecondsSinceUnixEpoch (): number {
   return Math.floor(Date.now() / 1000)
 }
@@ -374,7 +375,11 @@ async function assertTransactionFails (rawTx: string, reason: string): Promise<v
     await web3.eth.sendSignedTransaction(rawTx)
     fail("expected claim to fail, but it didn't")
   } catch (err) {
-    assert.isTrue(err.message.includes(reason), `unexpected revert reason: ${err.message}`)
+    if (err instanceof Error) {
+      assert.isTrue(err.message.includes(reason), `unexpected revert reason: ${err.message}`)
+    } else {
+      fail('Unknown error')
+    }
   }
 }
 

--- a/test/penalizer/Penalizer.test.ts
+++ b/test/penalizer/Penalizer.test.ts
@@ -45,6 +45,7 @@ contract('Penalizer', function ([relayOwner, relayWorker, relayManager, otherAcc
 
     // set up contracts
     penalizer = await Penalizer.new()
+    await penalizer.setHub(relayHub.address, { from: await penalizer.owner() })
     relayHub = await deployHub(penalizer.address)
     recipient = await TestRecipient.new()
     const verifier = await TestVerifierEverythingAccepted.new()
@@ -63,6 +64,9 @@ contract('Penalizer', function ([relayOwner, relayWorker, relayManager, otherAcc
   })
 
   describe('should be able to have its hub set', function () {
+    before(async function () {
+      await penalizer.setHub(zeroAddress(), { from: await penalizer.owner() })
+    })
     it('starting out with an unset address', async function () {
       assert.equal(await penalizer.getHub(), zeroAddress(), 'penalizer hub does not match zero address')
     })
@@ -264,10 +268,6 @@ contract('Penalizer', function ([relayOwner, relayWorker, relayManager, otherAcc
   })
 
   describe('should receive claims according with the commitment time', function () {
-    before(async function () {
-      await penalizer.setHub(relayHub.address, { from: await penalizer.owner() })
-    })
-
     describe('and accept them', () => {
       beforeEach(async () => {
         await relayHub.stakeForAddress(relayManager, 1000, {

--- a/test/penalizer/Penalizer.test.ts
+++ b/test/penalizer/Penalizer.test.ts
@@ -45,8 +45,8 @@ contract('Penalizer', function ([relayOwner, relayWorker, relayManager, otherAcc
 
     // set up contracts
     penalizer = await Penalizer.new()
-    await penalizer.setHub(relayHub.address, { from: await penalizer.owner() })
     relayHub = await deployHub(penalizer.address)
+    await penalizer.setHub(relayHub.address, { from: await penalizer.owner() })
     recipient = await TestRecipient.new()
     const verifier = await TestVerifierEverythingAccepted.new()
     const smartWalletTemplate = await SmartWallet.new()

--- a/test/penalizer/Penalizer.test.ts
+++ b/test/penalizer/Penalizer.test.ts
@@ -220,12 +220,7 @@ contract('Penalizer', function ([relayOwner, relayWorker, relayManager, otherAcc
         chainId
       )
 
-      try {
-        await web3.eth.sendSignedTransaction(rawTx)
-        fail("expected claim to fail, but it didn't")
-      } catch (err) {
-        assert.isTrue(err.message.includes("can't penalize fulfilled tx"), 'unexpected revert reason')
-      }
+      await assertTransactionFails(rawTx, "can't penalize fulfilled tx")
     })
 
     it('and accept them if tx is unfulfilled and unpenalized', async function () {
@@ -264,12 +259,7 @@ contract('Penalizer', function ([relayOwner, relayWorker, relayManager, otherAcc
         chainId
       )
 
-      try {
-        await web3.eth.sendSignedTransaction(rawTx)
-        fail("expected claim to fail, but it didn't")
-      } catch (err) {
-        assert.isTrue(err.message.includes('tx already penalized'), 'unexpected revert reason')
-      }
+      await assertTransactionFails(rawTx, 'tx already penalized')
     })
   })
 
@@ -298,7 +288,7 @@ contract('Penalizer', function ([relayOwner, relayWorker, relayManager, otherAcc
       ]
       allowedCommitmentTimes.forEach((timeDiff, index) => {
         it(`when the commit time is ${Math.abs(timeDiff)} seconds in the ${timeDiff < 0 ? 'past' : 'future'}`, async function () {
-          const [rr, sig] = await createRelayRequestAndSignature({ relayData: `0xdeadbeff1${index}`, enableQos: true })
+          const [rr, sig] = await createRelayRequestAndSignature({ relayData: `0xdeadbeef2${index}`, enableQos: true })
           const receipt = relayHelper.createReceipt(rr, sig, currentTimeInSeconds() + timeDiff)
           await relayHelper.signReceipt(receipt)
 
@@ -327,7 +317,7 @@ contract('Penalizer', function ([relayOwner, relayWorker, relayManager, otherAcc
       ]
       forbiddenCommitmentTime.forEach((timeDiff, index) => {
         it(`when the commit time is ${timeDiff} seconds in the future`, async function () {
-          const [rr, sig] = await createRelayRequestAndSignature({ relayData: `0xdeadbfef1${index}`, enableQos: true })
+          const [rr, sig] = await createRelayRequestAndSignature({ relayData: `0xdeadbeef3${index}`, enableQos: true })
           const receipt = relayHelper.createReceipt(rr, sig, currentTimeInSeconds() + timeDiff)
           await relayHelper.signReceipt(receipt)
 
@@ -348,7 +338,7 @@ contract('Penalizer', function ([relayOwner, relayWorker, relayManager, otherAcc
 
   it('claim should fail if no stake has been added back', async () => {
     // the stack previously added has been burned from previous successful claims
-    const [rr, sig] = await createRelayRequestAndSignature({ relayData: '0xdeadbfef10', enableQos: true })
+    const [rr, sig] = await createRelayRequestAndSignature({ relayData: '0xdeadbeef11', enableQos: true })
     const receipt = relayHelper.createReceipt(rr, sig)
     await relayHelper.signReceipt(receipt)
 
@@ -389,7 +379,6 @@ async function assertTransactionFails (rawTx: string, reason?: string): Promise<
   } catch (err) {
     if (reason === undefined || reason === null) {
       // we don't want to check why the transaction failed, but only if failed or not.
-      assert(true)
       return
     }
     if (!(err instanceof Error)) {

--- a/test/penalizer/Utils.ts
+++ b/test/penalizer/Utils.ts
@@ -113,13 +113,13 @@ export class RelayHelper {
     )
   }
 
-  createReceipt (relayRequest: RelayRequest, signature: string): CommitmentReceipt {
+  createReceipt (relayRequest: RelayRequest, signature: string, time: number = Math.floor(Date.now() / 1000)): CommitmentReceipt {
     const request = relayRequest.request
     const relayData = relayRequest.relayData
     return {
       workerAddress: relayData.relayWorker,
       commitment: {
-        time: 0,
+        time,
         from: request.from,
         to: request.to,
         data: request.data,

--- a/test/penalizer/Utils.ts
+++ b/test/penalizer/Utils.ts
@@ -113,13 +113,13 @@ export class RelayHelper {
     )
   }
 
-  createReceipt (relayRequest: RelayRequest, signature: string, time: number = Math.floor(Date.now() / 1000)): CommitmentReceipt {
+  createReceipt (relayRequest: RelayRequest, signature: string, time?: number): CommitmentReceipt {
     const request = relayRequest.request
     const relayData = relayRequest.relayData
     return {
       workerAddress: relayData.relayWorker,
       commitment: {
-        time,
+        time: time ?? currentTimeInSeconds(),
         from: request.from,
         to: request.to,
         data: request.data,
@@ -167,4 +167,8 @@ export async function fundAccount (fundedAccount: Address, destination: Address,
     value: web3.utils.toWei(ethAmount, 'ether'),
     gasPrice: gasPrice
   })
+}
+
+export function currentTimeInSeconds (): number {
+  return Math.floor(Date.now() / 1000)
 }


### PR DESCRIPTION
Comment out the `require` instruction that checks if the `claim` method is called too early.

~~builds on #164~~ 