### PR TITLE
Fix: Signature verify when create wallet (not using RELAY)

### DIFF
--- a/contracts/factory/CustomSmartWalletFactory.sol
+++ b/contracts/factory/CustomSmartWalletFactory.sol
@@ -112,6 +112,7 @@ contract CustomSmartWalletFactory is ICustomSmartWalletFactory {
         bytes calldata sig
     ) external override {
         bytes32 _hash = keccak256(abi.encodePacked(
+            address(this),
             owner,
             recoverer,
             logic,

--- a/contracts/factory/CustomSmartWalletFactory.sol
+++ b/contracts/factory/CustomSmartWalletFactory.sol
@@ -111,21 +111,17 @@ contract CustomSmartWalletFactory is ICustomSmartWalletFactory {
         bytes calldata initParams,
         bytes calldata sig
     ) external override {
-        bytes memory packed =
-            abi.encodePacked(
-                "\x19\x10",
-                owner,
-                recoverer,
-                logic,
-                index,
-                initParams
-            );
+        bytes32 _hash = keccak256(abi.encodePacked(
+            owner,
+            recoverer,
+            logic,
+            index,
+            initParams
+        ));
         (sig);
-        require(
-            RSKAddrValidator.safeEquals(keccak256(packed).recover(sig), owner),
-            "Invalid signature"
-        );
-
+        bytes32 message = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", _hash));
+        require(RSKAddrValidator.safeEquals(message.recover(sig),owner), "Invalid signature");
+        
         //e6ddc71a  =>  initialize(address owner,address logic,address tokenAddr,address tokenRecipient,uint256 tokenAmount,uint256 tokenGas,bytes initParams)
         bytes memory initData =
             abi.encodeWithSelector(

--- a/contracts/factory/SmartWalletFactory.sol
+++ b/contracts/factory/SmartWalletFactory.sol
@@ -107,15 +107,16 @@ contract SmartWalletFactory is ISmartWalletFactory {
         uint256 index,
         bytes calldata sig
     ) external override {
-        bytes memory packed = abi.encodePacked(
-            "\x19\x10",
+        bytes32 _hash = keccak256(abi.encodePacked(
+            address(this),
             owner,
             recoverer,
             index
-        );
-
-        require(RSKAddrValidator.safeEquals(keccak256(packed).recover(sig),owner), "Invalid signature");
-
+        ));
+        (sig);
+        bytes32 message = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", _hash));
+        require(RSKAddrValidator.safeEquals(message.recover(sig),owner), "Invalid signature");
+        
         //a6b63eb8  =>  initialize(address owner,address tokenAddr,address tokenRecipient,uint256 tokenAmount,uint256 tokenGas)  
         bytes memory initData = abi.encodeWithSelector(
             hex"a6b63eb8",

--- a/contracts/smartwallet/CustomSmartWallet.sol
+++ b/contracts/smartwallet/CustomSmartWallet.sol
@@ -80,6 +80,8 @@ contract CustomSmartWallet is IForwarder {
 
        bytes32 logicStrg;
         assembly {
+            // The logic contract address
+            // IMPLEMENTATION_SLOT = bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)
             logicStrg := sload(
                 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc
             )

--- a/contracts/smartwallet/SmartWallet.sol
+++ b/contracts/smartwallet/SmartWallet.sol
@@ -10,6 +10,9 @@ import "../utils/RSKAddrValidator.sol";
 /* solhint-disable avoid-low-level-calls */
 
 contract SmartWallet is IForwarder {
+    
+     //slot for owner = bytes32(uint256(keccak256('eip1967.proxy.owner')) - 1) = a7b53796fd2d99cb1f5ae019b54f9e024446c3d12b483f733ccc62ed04eb126a
+    bytes32 private constant _OWNER_SLOT = 0xa7b53796fd2d99cb1f5ae019b54f9e024446c3d12b483f733ccc62ed04eb126a;
     using ECDSA for bytes32;
 
     uint256 public override nonce;
@@ -28,7 +31,7 @@ contract SmartWallet is IForwarder {
     function getOwner() private view returns (bytes32 owner){
         assembly {
             owner := sload(
-                0xa7b53796fd2d99cb1f5ae019b54f9e024446c3d12b483f733ccc62ed04eb126a
+                _OWNER_SLOT
             )
         }
     }
@@ -114,7 +117,7 @@ contract SmartWallet is IForwarder {
             /* solhint-disable avoid-tx-origin */
             (success, ret) = req.tokenContract.call{gas: req.tokenGas}(
                 abi.encodeWithSelector(
-                    hex"a9059cbb", 
+                    hex"a9059cbb", //transfer(address,uint256) 
                     tx.origin,
                     req.tokenAmount
                 )
@@ -251,7 +254,7 @@ contract SmartWallet is IForwarder {
 
         assembly {
             sstore(
-                0xa7b53796fd2d99cb1f5ae019b54f9e024446c3d12b483f733ccc62ed04eb126a,
+                _OWNER_SLOT,
                 ownerCell
             )
         }
@@ -259,7 +262,7 @@ contract SmartWallet is IForwarder {
         //we need to initialize the contract
         if (tokenAmount > 0) {
             (bool success, bytes memory ret ) = tokenAddr.call{gas: tokenGas}(abi.encodeWithSelector(
-                hex"a9059cbb",
+                hex"a9059cbb", //transfer(address,uint256) 
                 tokenRecipient,
                 tokenAmount));
 


### PR DESCRIPTION
## Tests (BIG Disclaimer!!!)
- This has only been tested manually, no formal test developed nor modified in this PR so far, this is a draft.

## Context
When using the SmartWalletFactory contract without using the relay, directly from an EOA, the function "createUserSmartWallet" is called. This function checks if the signature belongs to the owner of the wallet and that the message signed is: `hash(<owner> + <recoverer> + <index>)`.

## Issue
Using Metamask/Nifty wallets at the moment of signing the message, a prefix is added so the final message would be:
`"\x19Ethereum Signed Message:\n" + msg.length + hash(<owner> + <recoverer> + <index>)`.
This is due to `eth_sign` is deprecated by those wallets:
- https://github.com/poanetwork/nifty-wallet/blob/master/CHANGELOG.md#399-2017-8-18
- https://github.com/MetaMask/metamask-extension/issues/2215

## Solution
So, in order to be compatible with this behaviour is that in this PR the verification of the signature (only in the case of direct deploy, without use of the RELAY mechanism) has been changed to the following:
- Message to sign in the **client** side is: `hash(<verifier_address> + <owner> + <recoverer> + <index>)`
- **Client** should use `presonal_sign` function (which prepends `"\x19Ethereum Signed Message:\n" + msg.length`).
- The recovery process in the Contract is: 
   - msg = `"\x19Ethereum Signed Message:\n" + msg.length + hash(<verifier_address>+<owner> + <recoverer> + <index>)`
   - `hash(msg).recover(signature)`
