### PR TITLE
Contributing Guidelines for RIF Relay

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -3,7 +3,7 @@ Thank you for investing your time in contributing to RIF Relay! Any contribution
 
 ## Understanding the Project
 RIF Relay is a secure transaction relay system that enables users to pay fees using ERC-20 tokens; it was inspired by the Gas Station Network (GSN) project. It comprises four main modules: RIF Relay Contracts, RIF Relay Common, RIF Relay Client, and RIF Relay Server, each with specific functionalities and roles within the system.
-Before contributing, we recommend familiarizing yourself with RIF Relay and it purpose. Please refer to the [`*Readme.md*`](https://github.com/rsksmart/rif-relay#readme) for detailed information. 
+Before contributing, we recommend familiarizing yourself with RIF Relay and it purpose. Please refer to the [`Readme.md`](https://github.com/rsksmart/rif-relay#readme) for detailed information. 
 
 ## New Contributor
 To get an overview of the project, read the README in the respective RIF Relay module repository. Here are some resources to help you get started:

--- a/contributing.md
+++ b/contributing.md
@@ -6,7 +6,7 @@ RIF Relay is a secure transaction relay system that enables users to pay fees us
 Before contributing, we recommend familiarizing yourself with RIF Relay and its purpose. Please refer to the [`Readme.md`](https://github.com/rsksmart/rif-relay#readme) for detailed information. 
 
 ## New Contributor
-To get an overview of the project, read the README in the respective RIF Relay module repository. Here are some resources to help you get started:
+To get an overview of the project, read the [README](https://github.com/rsksmart/rif-relay#rif-relay) in the respective RIF Relay module repository. Here are some resources to help you get started:
 - Read the Code of Conduct.
 - How to make a contribution: Follow the steps outlined below.
 - Where to go for help? Join the [Rootstock Open Discord](https://rootstock.io/discord) for community support.

--- a/contributing.md
+++ b/contributing.md
@@ -2,7 +2,7 @@
 Thank you for investing your time in contributing to RIF Relay! Any contribution you make will be reflected on the [RIF Relay GitHub page](https://github.com/rsksmart/rif-relay). Your efforts help improve the Rootstock and RIF ecosystem.
 
 ## Understanding the Project
-RIF Relay is a secure transaction relay system that enables users to pay fees using ERC-20 tokens; it was inspired by the Gas Station Network (GSN) project. It comprises four main modules: RIF Relay Contracts, RIF Relay Common, RIF Relay Client, and RIF Relay Server, each with specific functionalities and roles within the system.
+RIF Relay is a secure transaction relay system that enables users to pay fees using ERC-20 tokens; it was inspired by the Gas Station Network (GSN) project. It comprises four main modules: RIF Relay Contracts, RIF Relay Client, and RIF Relay Server, each with specific functionalities and roles within the system.
 Before contributing, we recommend familiarizing yourself with RIF Relay and it purpose. Please refer to the [`Readme.md`](https://github.com/rsksmart/rif-relay#readme) for detailed information. 
 
 ## New Contributor

--- a/contributing.md
+++ b/contributing.md
@@ -51,6 +51,3 @@ To get an overview of the project, read the [README](https://github.com/rsksmart
 - Follow the testing instructions in the [Readme.md](https://github.com/rsksmart/rif-relay#readme) to run tests.
 - Ensure all tests pass before submitting a PR.
 
-**Where to go for help**
-- Contributors can seek help on the [Rootstock Open Discord](https://rootstock.io/discord).
-

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,56 @@
+# Rootstock Contribution Guidelines - RIF Relay
+Thank you for investing your time in contributing to RIF Relay! Any contribution you make will be reflected on the [RIF Relay GitHub page](https://github.com/rsksmart/rif-relay). Your efforts help improve the Rootstock and RIF ecosystem.
+
+## Understanding the Project
+RIF Relay is a secure transaction relay system that enables users to pay fees using ERC-20 tokens; it was inspired by the Gas Station Network (GSN) project. It comprises four main modules: RIF Relay Contracts, RIF Relay Common, RIF Relay Client, and RIF Relay Server, each with specific functionalities and roles within the system.
+Before contributing, we recommend familiarizing yourself with RIF Relay and it purpose. Please refer to the [`*Readme.md*`] (https://github.com/rsksmart/rif-relay#readme) for detailed information. 
+
+## New Contributor
+To get an overview of the project, read the README in the respective RIF Relay module repository. Here are some resources to help you get started:
+- Read the Code of Conduct.
+- How to make a contribution: Follow the steps outlined below.
+- Where to go for help? Join the [Rootstock Open Discord] (https://rootstock.io/discord) for community support.
+- Credits and Attribution: Contributors are acknowledged in the project documentation.
+
+### How do I make a contribution?
+
+**Reporting a Bug**
+1. To report a bug, submit an issue on the GitHub repository with:
+   - A clear and descriptive title.
+   - A concise and specific description of the bug.
+   - Steps to reproduce the issue.
+   - Expected behavior and what actually happens.
+   - Any relevant screenshots or error messages.
+
+**Submitting a Fix**
+1. Fork the repository.
+2. Create a new branch for your fix.
+3. Make your changes in the new branch.
+4. Commit your changes with a descriptive commit message.
+5. Push the branch to your fork.
+6. Submit a pull request against the main branch of the original repository.
+
+**Proposing New Features**
+1. Open an issue on the GitHub repository describing the feature.
+2. Discuss the feasibility and relevance of the feature with the project maintainers.
+3. Once approved, follow the steps for submitting a fix to implement the feature.
+
+**How to Submit an Issue**
+1. Fork the repository and create a new branch for your changes.
+2. Make your changes and commit them.
+3. Push your branch to your fork.
+4. Go to the original repository and click on ‘New Pull Request’.
+5. Select your branch and provide a detailed description of your changes.
+6. Submit the pull request for review.
+
+**How to Submit a PR**
+1. Follow the same steps as submitting an issue, ensuring your changes are in a separate branch.
+2. Provide a clear and detailed description of the changes in the PR.
+
+**Testing**
+- Follow the testing instructions in the [Readme.md] (https://github.com/rsksmart/rif-relay#readme) to run tests.
+- Ensure all tests pass before submitting a PR.
+
+**Where to go for help**
+- Contributors can seek help on the [Rootstock Open Discord] (https://rootstock.io/discord).
+

--- a/contributing.md
+++ b/contributing.md
@@ -3,7 +3,7 @@ Thank you for investing your time in contributing to RIF Relay! Any contribution
 
 ## Understanding the Project
 RIF Relay is a secure transaction relay system that enables users to pay fees using ERC-20 tokens; it was inspired by the Gas Station Network (GSN) project. It comprises four main modules: RIF Relay Contracts, RIF Relay Client, and RIF Relay Server, each with specific functionalities and roles within the system.
-Before contributing, we recommend familiarizing yourself with RIF Relay and it purpose. Please refer to the [`Readme.md`](https://github.com/rsksmart/rif-relay#readme) for detailed information. 
+Before contributing, we recommend familiarizing yourself with RIF Relay and its purpose. Please refer to the [`Readme.md`](https://github.com/rsksmart/rif-relay#readme) for detailed information. 
 
 ## New Contributor
 To get an overview of the project, read the README in the respective RIF Relay module repository. Here are some resources to help you get started:

--- a/contributing.md
+++ b/contributing.md
@@ -33,7 +33,7 @@ To get an overview of the project, read the README in the respective RIF Relay m
 **Proposing New Features**
 1. Open an issue on the GitHub repository describing the feature.
 2. Discuss the feasibility and relevance of the feature with the project maintainers.
-3. Once approved, follow the steps for submitting a fix to implement the feature.
+3. Once approved, follow the steps to submit the changes required to implement the feature.
 
 **How to Submit an Issue**
 1. Fork the repository and create a new branch for your changes.

--- a/contributing.md
+++ b/contributing.md
@@ -22,22 +22,14 @@ To get an overview of the project, read the [README](https://github.com/rsksmart
    - Expected behavior and what actually happens.
    - Any relevant screenshots or error messages.
 
-**Submitting a Fix**
-1. Fork the repository.
-2. Create a new branch for your fix.
-3. Make your changes in the new branch.
-4. Commit your changes with a descriptive commit message.
-5. Push the branch to your fork.
-6. Submit a pull request against the main branch of the original repository.
-
 **Proposing New Features**
 1. Open an issue on the GitHub repository describing the feature.
 2. Discuss the feasibility and relevance of the feature with the project maintainers.
 3. Once approved, follow the steps to submit the changes required to implement the feature.
 
-**How to Submit an Issue**
+**How to Submit an Issue or Fix**
 1. Fork the repository and create a new branch for your changes.
-2. Make your changes and commit them.
+2. Make your changes in the new branch and commit them.
 3. Push your branch to your fork.
 4. Go to the original repository and click on ‘New Pull Request’.
 5. Select your branch and provide a detailed description of your changes.

--- a/contributing.md
+++ b/contributing.md
@@ -3,13 +3,13 @@ Thank you for investing your time in contributing to RIF Relay! Any contribution
 
 ## Understanding the Project
 RIF Relay is a secure transaction relay system that enables users to pay fees using ERC-20 tokens; it was inspired by the Gas Station Network (GSN) project. It comprises four main modules: RIF Relay Contracts, RIF Relay Common, RIF Relay Client, and RIF Relay Server, each with specific functionalities and roles within the system.
-Before contributing, we recommend familiarizing yourself with RIF Relay and it purpose. Please refer to the [`*Readme.md*`] (https://github.com/rsksmart/rif-relay#readme) for detailed information. 
+Before contributing, we recommend familiarizing yourself with RIF Relay and it purpose. Please refer to the [`*Readme.md*`](https://github.com/rsksmart/rif-relay#readme) for detailed information. 
 
 ## New Contributor
 To get an overview of the project, read the README in the respective RIF Relay module repository. Here are some resources to help you get started:
 - Read the Code of Conduct.
 - How to make a contribution: Follow the steps outlined below.
-- Where to go for help? Join the [Rootstock Open Discord] (https://rootstock.io/discord) for community support.
+- Where to go for help? Join the [Rootstock Open Discord](https://rootstock.io/discord) for community support.
 - Credits and Attribution: Contributors are acknowledged in the project documentation.
 
 ### How do I make a contribution?
@@ -48,9 +48,9 @@ To get an overview of the project, read the README in the respective RIF Relay m
 2. Provide a clear and detailed description of the changes in the PR.
 
 **Testing**
-- Follow the testing instructions in the [Readme.md] (https://github.com/rsksmart/rif-relay#readme) to run tests.
+- Follow the testing instructions in the [Readme.md](https://github.com/rsksmart/rif-relay#readme) to run tests.
 - Ensure all tests pass before submitting a PR.
 
 **Where to go for help**
-- Contributors can seek help on the [Rootstock Open Discord] (https://rootstock.io/discord).
+- Contributors can seek help on the [Rootstock Open Discord](https://rootstock.io/discord).
 


### PR DESCRIPTION
## What

- Created a Contributing Guidelines for RIF Relay

## Why

- It helps maintain consistency in code, documentation, and other contributions. 
- It sets a standard for quality, ensuring that all contributions meet the project's requirements.

## Refs

- (optional: include links to other issues, PRs, tickets, etc)
